### PR TITLE
fix: ensure modal appears above overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -316,7 +316,6 @@ input[name="telefone"] { width:18ch; }
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
 }
 #app-modal[hidden] { display: none; }
 #app-modal .modal-overlay {


### PR DESCRIPTION
## Summary
- remove z-index override from `#app-modal` so default `.modal` stacking applies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20755fea0833398776f8343d9896d