### PR TITLE
Reset modal save button id on close

### DIFF
--- a/script.js
+++ b/script.js
@@ -953,7 +953,7 @@ function openClienteModal(id, onSave) {
         </div>
         `}
       </form>`;
-  const saveBtn = modal.querySelector('#modal-save');
+  const saveBtn = modal.querySelector('#clientSaveBtn') || modal.querySelector('#modal-save');
   saveBtn.setAttribute('form','cliente-form');
   saveBtn.id = 'clientSaveBtn';
   const cancelBtn = modal.querySelector('[data-modal-close]');
@@ -2230,11 +2230,17 @@ function closeModal(id){
 }
 
 function closeClientModal(){
+  const modal = document.getElementById('app-modal');
+  const saveBtn = modal?.querySelector('#clientSaveBtn') || modal?.querySelector('#purchaseSaveBtn') || modal?.querySelector('#modal-save');
+  if (saveBtn) saveBtn.id = 'modal-save';
   closeModal('clientModal');
   refreshUI();
 }
 
 function closePurchaseModal(){
+  const modal = document.getElementById('app-modal');
+  const saveBtn = modal?.querySelector('#purchaseSaveBtn') || modal?.querySelector('#clientSaveBtn') || modal?.querySelector('#modal-save');
+  if (saveBtn) saveBtn.id = 'modal-save';
   closeModal('purchaseModal');
   refreshUI();
 }


### PR DESCRIPTION
## Summary
- Ensure `openClienteModal` finds the save button even if its ID was changed in a previous modal interaction
- Reset save button ID back to `modal-save` whenever client or purchase modals close

## Testing
- `npm test`
- Attempted to run a Node-based modal open/close cycle using jsdom but installation failed with `403 Forbidden`


------
https://chatgpt.com/codex/tasks/task_e_68a2124e943c83338f6c80c85c8b4a78