### PR TITLE
Fix refreshUI order to avoid undefined render functions

### DIFF
--- a/script.js
+++ b/script.js
@@ -2240,7 +2240,7 @@ function closePurchaseModal(){
 }
 
 function refreshUI(){
-  renderClientsTable?.();
+  window.renderClientsTable?.();
   renderSelectedPurchaseDetails?.();
   renderCalendarMonth?.();
   renderDashboard?.();
@@ -2349,8 +2349,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
   applyPerfilGates();
   await limparCachesJoaoClaro();
-  refreshUI();
   renderRoute(location.hash.slice(2) || 'dashboard');
+  refreshUI();
 });
 
 window.addEventListener('hashchange', () => renderRoute(location.hash.slice(2) || 'dashboard'));


### PR DESCRIPTION
## Summary
- Call `renderRoute` before `refreshUI` on DOMContentLoaded to define renderers
- Use `window.renderClientsTable` within `refreshUI` to ensure global lookup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2124f5158833389b0bfdb64c6948d