### PR TITLE
feat: add modal opener for selected client

### DIFF
--- a/script.js
+++ b/script.js
@@ -260,6 +260,13 @@ let currentClientId = null;
 let currentClientPurchases = [];
 let renderSelectedPurchaseDetails = null;
 
+function openPurchaseModalForSelected(){
+  const id = state.getClienteSelecionadoId();
+  if(!id) return toast('Selecione um cliente');
+  openCompraModal(id);
+}
+window.openPurchaseModalForSelected = openPurchaseModalForSelected;
+
 function setActivePurchaseChip(id){
   document.querySelectorAll('#purchaseTabs [data-purchase-id]').forEach(el=>{
     el.classList.toggle('active', el.dataset.purchaseId===id);


### PR DESCRIPTION
## Summary
- add `openPurchaseModalForSelected` to open purchase modal for currently selected client
- expose new modal function on `window`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21f2c20e88333afa5a841034b7362