### PR TITLE
Replace test profile and fix modal save actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
           <option value="Exótica">Exótica</option>
           <option value="Jorel Chicuta">Jorel Chicuta</option>
           <option value="Jorel Avenida">Jorel Avenida</option>
-          <option value="Teste">Teste</option>
+          <option value="Usuario Teste">Usuario Teste</option>
         </select>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- remove legacy 'Teste' profile data and introduce clean 'Usuario Teste'
- ensure saving clients and purchases closes modals and keeps buttons active
- guard follow-up scheduling against invalid dates to avoid RangeError

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a326e586c48333af2852fe9c9cc47e