### PR TITLE
Fix client purchase saving and dashboard colors

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ function deleteClient(clientId, profile=currentProfile()){
     return cid !== clientId;
   });
   setCalendar(cal, profile);
-  renderClientsTable?.(); renderCalendarMonth?.(); renderDashboard?.();
+  window.renderClientsTable?.(); renderCalendarMonth?.(); renderDashboard?.();
 }
 
 function deletePurchase(purchaseId, clientId, profile=currentProfile()){
@@ -89,7 +89,7 @@ function deletePurchase(purchaseId, clientId, profile=currentProfile()){
   setClients(clients, profile);
   const cal = getCalendar(profile).filter(ev => ev.meta?.purchaseId !== purchaseId);
   setCalendar(cal, profile);
-  renderClientsTable?.();
+  window.renderClientsTable?.();
   renderCalendarMonth?.();
   renderDashboard?.();
   renderSelectedPurchaseDetails?.();
@@ -144,7 +144,7 @@ function seedAllDash(){ PROFILES.forEach(ensureSeed); }
 function onProfileChanged(){
   ensureSeed(getPerfil());
   renderDashboard();
-  renderClientsTable?.();
+  window.renderClientsTable?.();
   renderCalendarMonth?.();
 }
 
@@ -163,7 +163,10 @@ function upsertEvent(list, ev){
 }
 
 function scheduleFollowUpsForPurchase(cliente, compra){
-  const cal = getCalendar();
+  let cal = getCalendar();
+  // Remove qualquer evento laranja residual desta compra
+  cal = cal.filter(ev => !(ev.meta?.purchaseId === compra.id && ev.meta?.kind === 'purchase' && ev.color === 'orange'));
+
   const baseId = `${currentProfile()}:${cliente.id}:${compra.id}:0`;
   const baseDate = parseDDMMYYYY(compra.dataCompra);
   if(isNaN(baseDate)) return;
@@ -304,7 +307,7 @@ function renderTagMenu(){
   document.getElementById('tagMenuContent')?.addEventListener('change',e=>{
     const cb=e.target.closest('input[type="checkbox"][data-tag]'); if(!cb) return;
     toggleTagFilter(cb.dataset.tag, cb.checked);
-    renderClientsTable?.();
+    window.renderClientsTable?.();
   });
 }
 
@@ -1932,6 +1935,7 @@ function renderWidgetContent(cardInner, slot){
   if(slot.id === 'widget.clientsCount'){
     title.textContent = 'Quantidade de clientes';
     value.textContent = String(getClients().length);
+    cardInner.parentElement?.classList.add('card-success');
   } else if(slot.id === 'widget.followupsToday'){
     title.textContent = 'Contatos para Hoje';
     value.textContent = String(getFollowupsStats().todayCount);
@@ -2172,24 +2176,24 @@ function readClientForm(){
     id: document.getElementById('cliente-id')?.value || null,
     nome: document.getElementById('cliente-nome').value.trim(),
     telefone: document.getElementById('cliente-telefone').value.trim(),
-    nascimento: document.getElementById('cliente-dataNascimento').value.trim(),
+    dataNascimento: document.getElementById('cliente-dataNascimento').value.trim(),
     cpf: document.getElementById('cliente-cpf').value.trim(),
     usos: getSelectedTagUsosFromForm(),
     compras: []
   };
 
-  const dataCompraEl = document.getElementById('dataCompra');
+  const dataCompraEl = document.getElementById('compra-data');
   if(dataCompraEl){
     const compra = {
       id: `cmp_${Date.now()}_${Math.random().toString(36).slice(2,7)}`,
       dataCompra: dataCompraEl.value,
-      valorLente: parseCurrency(document.getElementById('valorLente')?.value),
+      valorLente: parseCurrency(document.getElementById('compra-valor')?.value),
       nfe: document.getElementById('compra-nfe')?.value.trim() || '',
-      armacao: document.getElementById('armacao')?.value.trim() || '',
-      armacaoMaterial: document.querySelector('#armacao-material .seg-btn[aria-pressed="true"]')?.dataset.value || '',
-      lente: document.getElementById('lente')?.value.trim() || '',
-      tiposCompra: Array.from(document.querySelectorAll('#tipos-compra .seg-btn[aria-pressed="true"]')).map(b=>b.dataset.value),
-      observacoes: document.getElementById('obs-compra')?.value.trim() || '',
+      armacao: document.getElementById('compra-armacao')?.value.trim() || '',
+      armacaoMaterial: document.querySelector('#compra-material .seg-btn[aria-pressed="true"]')?.dataset.value || '',
+      lente: document.getElementById('compra-lente')?.value.trim() || '',
+      tiposCompra: Array.from(document.querySelectorAll('#compra-tipos .seg-btn[aria-pressed="true"]')).map(b=>b.dataset.value),
+      observacoes: document.getElementById('compra-observacoes')?.value.trim() || '',
       receituario: {
         oe: {
           esferico: document.querySelector('[name="oe_esferico"]')?.value.trim() || '',

--- a/style.css
+++ b/style.css
@@ -28,9 +28,9 @@
   --surface-muted: var(--color-app-bg);
   --text-muted: var(--text-weak);
   --control-height: 40px;
-  --card-danger-soft: #fdecea;
-  --card-success-soft: #e8f5e9;
-  --card-info-soft: #e3f2fd;
+  --card-danger-soft: #f8d7da;
+  --card-success-soft: #d4edda;
+  --card-info-soft: #d1ecf1;
 }
 html.theme-dark {
   --color-app-bg: #121212;
@@ -686,9 +686,9 @@ input[name="telefone"] { width:18ch; }
 .dash-slot{border:2px dashed #cfd3d8;border-radius:10px;min-height:140px;background:#fafafa;position:relative}
 .dash-card{border-radius:10px;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.08);height:100%;display:flex;align-items:center;justify-content:center;font-weight:700}
 .dash-title{font-weight:800;font-size:1rem;margin-bottom:6px}
-.card-info{background:#e6f2ff}
-.card-success{background:#e8f8ef}
-.card-danger{background:#ffecec}
+.card-info{background:var(--card-info-soft)}
+.card-success{background:var(--card-success-soft)}
+.card-danger{background:var(--card-danger-soft)}
 .tag-menu{position:fixed;z-index:950;min-width:220px;max-height:60vh;overflow:auto;background:#fff;border:1px solid #dadde2;border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,.15);padding:8px;display:grid;grid-template-columns:1fr;gap:6px}
 .tag-row{display:flex;align-items:center;justify-content:space-between;gap:8px}
 .tag-row label{font-weight:600}
@@ -741,9 +741,9 @@ input[name="telefone"] { width:18ch; }
 .event.followup, .event-color-followup, .calendar-chip.followup, .calendar-card.followup { background:#bfe0ff; color:#0c2a4a; }
 
 /* paletas padrão (usar quando houver widgets de status) */
-.card-info{background:#e6f2ff}
-.card-success{background:#e8f8ef}
-.card-danger{background:#ffecec}
+.card-info{background:var(--card-info-soft)}
+.card-success{background:var(--card-success-soft)}
+.card-danger{background:var(--card-danger-soft)}
 .purchase-card{position:relative}
 .purchase-date-badge{position:absolute; right:12px; top:10px; font-weight:800; font-size:1rem}
 .profile-admin{background:#eaf8ee}


### PR DESCRIPTION
## Summary
- fix client form to persist purchase data correctly
- ensure only green purchase events and clean up stray orange entries
- add default coloring for dashboard widgets and guard renderClientsTable on profile change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a331a863a08333ac94a4bdcbf2ae16