### PR TITLE
fix: keep follow-up popover and selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -563,7 +563,7 @@ function removeFollowUpEvents(clienteId,compraId){
     reloadCalendario();
     renderDashboard();
   },
-  atualizarCompra(clienteId, compraId, patch) {
+  atualizarCompra(clienteId, compraId, patch, opts = {}) {
     const data = this._get();
     const cIdx = data.findIndex(c => c.id === clienteId);
     if (cIdx === -1) return;
@@ -575,8 +575,8 @@ function removeFollowUpEvents(clienteId,compraId){
     scheduleFollowUpsForPurchase(data[cIdx], compras[compIdx]);
     data[cIdx].atualizadoEm = new Date().toISOString();
     this._set(data);
-    reloadCalendario();
-    renderDashboard();
+    if (!opts.skipReload) reloadCalendario();
+    if (!opts.skipDashboard) renderDashboard();
   },
   adicionarCompra(clienteId, compra) {
     const data = this._get();
@@ -1267,7 +1267,7 @@ function initCalendarioPage() {
         fu.eventId=ev.id;
         fu.dueDateISO=fu.dueDateISO||ev.date;
         if(stage) compra.followUps[stage]=fu;
-        db.atualizarCompra(cliente.id, compra.id, {followUps: compra.followUps});
+        db.atualizarCompra(cliente.id, compra.id, {followUps: compra.followUps}, {skipReload:true, skipDashboard:true});
       }
     }
     renderDashboard();


### PR DESCRIPTION
## Summary
- avoid reloading calendar when toggling follow-up status
- persist toggle state and remove red indicator without jumping to current month

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4865f79c48333b51b276b0ec10ca7