### PR TITLE
Refresh dashboard and calendar after follow-up changes

### DIFF
--- a/script.js
+++ b/script.js
@@ -1852,7 +1852,8 @@ function initClientesPage() {
             fu.done=input.checked;
             fu.doneAt=fu.done?new Date().toISOString():null;
             cp.followUps[period]=fu;
-            db.atualizarCompra(id, cpId, { followUps: cp.followUps });
+            db.atualizarCompra(id, cpId, { followUps: cp.followUps }, { skipReload: true, skipDashboard: true });
+            renderCalendarMonth();
             renderDashboard();
           });
         });


### PR DESCRIPTION
## Summary
- Skip automatic reload when toggling follow-up checkboxes
- Manually refresh calendar and dashboard after follow-up updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48bfb08a883339f26397ce1b7e324