### PR TITLE
fix: keep follow-up popover open when toggling

### DIFF
--- a/script.js
+++ b/script.js
@@ -1588,10 +1588,11 @@ function initCalendarioPage() {
       if(!layer) return;
       layer.appendChild(pop);
       positionPopover(target,pop);
-      const chk=pop.querySelector('.switch');
-      if(chk){
-        chk.addEventListener('click',e=>e.stopPropagation());
-        chk.addEventListener('change',()=>onToggleFollowUp(ev,chk.checked));
+      const lbl=pop.querySelector('.pop-footer label');
+      if(lbl){
+        lbl.addEventListener('click',e=>e.stopPropagation());
+        const chk=lbl.querySelector('.switch');
+        if(chk) chk.addEventListener('change',()=>onToggleFollowUp(ev,chk.checked));
       }
       setupPopoverDismiss(pop,target);
       return;


### PR DESCRIPTION
## Summary
- stop click events on follow-up popover label so toggling the switch doesn't close the popover

## Testing
- `npm test`
- `npm install jsdom --no-save` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68a48bfc6d24833389c8f3923a9cff4a