### PR TITLE
fix: reset calendar view on page reload

### DIFF
--- a/script.js
+++ b/script.js
@@ -1181,7 +1181,7 @@ function initCalendarioPage() {
   const weekdaysEl = wrapper.querySelector('.cal-weekdays');
   const dias = ['Dom','Seg','Ter','Qua','Qui','Sex','Sáb'];
   dias.forEach(d => { const div = document.createElement('div'); div.textContent = d; weekdaysEl.appendChild(div); });
-  let currentDate = window.currentDate || new Date();
+  let currentDate = new Date();
   window.currentDate = currentDate;
   let modo = 'mes';
   const eventosKey = calKey();
@@ -2273,9 +2273,10 @@ async function limparCachesJoaoClaro(){
 
 function reloadCalendario(currentDate){
   purgeOrphanEvents();
+  const date = currentDate ?? window.currentDate ?? new Date();
   if(currentRoute==='calendario'){
     if(typeof renderCalendarMonth === 'function'){
-      renderCalendarMonth(currentDate ?? window.currentDate);
+      renderCalendarMonth(date);
     }else{
       renderRoute('calendario');
     }


### PR DESCRIPTION
## Summary
- initialize calendar with new Date instead of cached value
- ensure calendar reload defaults to current date when unspecified

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ba952c3c83339b2e47f403bfa150