### PR TITLE
feat: enhance kanban with filters and pagination

### DIFF
--- a/style.css
+++ b/style.css
@@ -34,6 +34,10 @@
   --os-reloj-color: #183C7A;
   --os-joia-color: #C99700;
   --os-optica-color: #8B1E1E;
+  --kanban-loja: rgba(46, 160, 67, 0.06);
+  --kanban-oficina: rgba(255, 159, 10, 0.08);
+  --kanban-aguardo: rgba(56, 139, 253, 0.07);
+  --kanban-completo: rgba(46, 160, 67, 0.12);
 }
 html.theme-dark {
   --color-app-bg: #121212;
@@ -51,6 +55,10 @@ html.theme-dark {
   --red-600: #c62828;
   --red-400: #e57373;
   --orange-500: var(--accent-orange);
+  --kanban-loja: rgba(46, 160, 67, 0.06);
+  --kanban-oficina: rgba(255, 159, 10, 0.08);
+  --kanban-aguardo: rgba(56, 139, 253, 0.07);
+  --kanban-completo: rgba(46, 160, 67, 0.12);
 }
 body {
   margin: 0;
@@ -306,8 +314,18 @@ input[name="telefone"] { width:18ch; }
 .os-filters{display:flex; flex-wrap:wrap; gap:8px;}
 .os-filters input, .os-filters select{height:var(--control-height);}
 .os-kanban { display: flex; gap: 1rem; align-items: flex-start; }
-.os-kanban .kanban-col { flex: 1; background: var(--surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: 0.5rem; min-height: 200px; }
-.os-kanban .kanban-col h3 { margin: 0 0 0.5rem; font-size: 1rem; display: flex; justify-content: space-between; }
+.os-kanban .kanban-col { flex: 1; border: 1px solid var(--color-border); border-radius: var(--radius-lg); min-height: 200px; padding: 0; display:flex; flex-direction:column; }
+.os-kanban .kanban-col .kanban-header { text-align:center; font-weight:bold; font-size:1.125rem; padding:0.5rem; border-bottom:1px solid var(--color-border); }
+.os-kanban .kanban-col .kanban-header h3 { margin:0; font-size:inherit; font-weight:inherit; }
+.os-kanban .kanban-col .cards { flex:1; padding:0.5rem; }
+.os-kanban .kanban-col .kanban-footer { border-top:1px solid var(--color-border); padding:0.5rem; display:flex; justify-content:center; align-items:center; gap:0.5rem; font-size:0.875rem; }
+.os-kanban .kanban-col .kanban-footer button { background:none; border:none; cursor:pointer; color:var(--color-text); }
+.os-kanban .kanban-col .kanban-footer button:disabled { opacity:0.5; cursor:default; }
+.os-kanban .kanban-col .kanban-footer .sep{opacity:0.6;}
+.col-kanban--loja{background-color:var(--kanban-loja);}
+.col-kanban--oficina{background-color:var(--kanban-oficina);}
+.col-kanban--aguardo{background-color:var(--kanban-aguardo);}
+.col-kanban--completo{background-color:var(--kanban-completo);}
 .os-card { border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: 0.5rem; overflow: hidden; }
 .os-card-head { padding: 4px 8px; font-weight: bold; color: #fff; }
 .os-card.reloj { border-color: var(--os-reloj-color); }
@@ -325,6 +343,10 @@ input[name="telefone"] { width:18ch; }
 .os-card-actions { padding: 4px 8px; display: flex; flex-wrap: wrap; gap: 4px; }
 .os-move-select { margin-left: 4px; }
 .os-kanban .kanban-col.drag-over { outline:2px dashed var(--os-reloj-color); }
+.os-type-filter{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:1rem;}
+.os-type-filter .filter-btn{padding:0.5rem 1rem;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--surface);cursor:pointer;}
+.os-type-filter .filter-btn.active{background:var(--color-primary);color:#fff;}
+.os-type-filter .filter-btn:focus{outline:2px solid var(--color-primary);}
 .os-type-choices{display:flex;gap:8px;flex-wrap:wrap;}
 .os-type{padding:12px;border:0;border-radius:var(--radius-md);color:#fff;cursor:pointer;}
 .os-type-reloj{background:var(--os-reloj-color);}
@@ -804,3 +826,8 @@ input[name="telefone"] { width:18ch; }
           mask:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="%23000" d="M6.62 10.79a15.05 15.05 0 006.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V21c0 .55-.45 1-1 1C10.85 22 2 13.15 2 2c0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.24.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/></svg>') center/contain no-repeat;
 }
 .cli-phone{font-weight:800}
+
+@media (max-width:600px){
+  .os-kanban{flex-wrap:nowrap;overflow-x:auto;scroll-snap-type:x mandatory;}
+  .os-kanban .kanban-col{flex:0 0 80%;scroll-snap-align:start;}
+}


### PR DESCRIPTION
## Summary
- add subtle background colors and styled headers for each kanban column
- implement type filter buttons and per-column pagination with counts
- enable responsive horizontal scrolling for kanban on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5dbc225a48333a31dbbc0a7feba71