### PR TITLE
feat: add store profile management and user photo

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <!-- Sidebar -->
   <nav class="sidebar" aria-label="Navegação principal">
-    <div id="profileBadge" class="brand-tile" aria-label="Nome da loja">OPTICA</div>
+    <div id="profileBadge" class="brand-tile" aria-label="Perfil atual"></div>
     <div class="brand-divider" role="presentation"></div>
     <ul>
       <li class="nav-item" data-route="dashboard" tabindex="0"><span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg></span><span class="label">Dashboard</span></li>

--- a/style.css
+++ b/style.css
@@ -822,7 +822,54 @@ input[name="telefone"] { width:18ch; }
 .purchase-date-badge{position:absolute; right:12px; top:10px; font-weight:800; font-size:1rem}
 .profile-admin{background:#eaf8ee}
 .profile-other{background:#ffecec}
-#profileBadge{border-radius:12px;padding:18px 20px;font-weight:800}
+#profileBadge{
+  border-radius:12px;
+  padding:18px 20px;
+  font-weight:800;
+  text-align:center;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+  height:auto;
+}
+
+#profileBadge .profile-pic{
+  width:72px;
+  height:72px;
+  border-radius:50%;
+  object-fit:cover;
+  object-position:50% 50%;
+}
+
+#profileBadge.editable .profile-pic{cursor:move;}
+#profileBadge.editable{cursor:pointer;}
+
+#profileBadge .profile-name{font-weight:800;}
+
+#profileBadge .profile-placeholder{
+  width:72px;
+  height:72px;
+  border-radius:50%;
+  background:var(--neutral-200);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:1.5rem;
+}
+
+.loja-logo-preview{
+  width:80px;
+  height:80px;
+  border-radius:50%;
+  object-fit:cover;
+  object-position:center;
+}
+
+.loja-logo-field{display:flex;align-items:center;gap:8px;}
+
+.loja-nome{font-weight:600;margin-top:4px;}
 
 #clientSearch{height:38px; border-radius:12px; padding:0 14px}
 #tagMenuBtn,#addClientBtn{height:38px}


### PR DESCRIPTION
## Summary
- add per-profile store widget with logo, contact, and social fields
- enable sidebar user photo upload and drag reposition
- include store name and Instagram link on service order prints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f6a8f6c483338a415b7e504c20b1