### PR TITLE
feat(admin): add warranty notes management

### DIFF
--- a/style.css
+++ b/style.css
@@ -338,6 +338,12 @@ input[name="telefone"] { width:18ch; }
 .os-card-dates{margin-top:8px;font-weight:bold;}
 .badge{display:inline-block;padding:2px 4px;border-radius:var(--radius-sm);font-size:0.75rem;}
 .os-card .badge{color:#fff;}
+
+.garantia-page{display:flex;flex-direction:column;gap:1rem;max-width:600px;margin:0 auto;}
+.garantia-block{background:var(--surface);box-shadow:var(--card-shadow);padding:1rem;border-radius:var(--radius-md);display:flex;flex-direction:column;}
+.garantia-block h3{margin-top:0;font-weight:700;}
+.garantia-block textarea{width:100%;min-height:120px;}
+.garantia-block button{align-self:flex-start;margin-top:0.5rem;}
 .os-card.reloj .badge{background: var(--os-reloj-color);}
 .os-card.joia .badge{background: var(--os-joia-color);}
 .os-card.optica .badge{background: var(--os-optica-color);}


### PR DESCRIPTION
## Summary
- replace OS Kanban with warranty notes editor for Administrador
- store warranty notes per type and auto-fill read-only field in OS forms
- style warranty notes blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f9d074d483338f74eb718de196f0