### PR TITLE
feat: add optica service order template

### DIFF
--- a/features/os/index.js
+++ b/features/os/index.js
@@ -1,2 +1,4 @@
-// placeholder for ordem de servico feature
-export default {};
+import optica from './optica.js';
+
+export { optica };
+export default { optica };

--- a/features/os/optica.js
+++ b/features/os/optica.js
@@ -1,0 +1,42 @@
+// Configuração da O.S. para Óptica
+
+export function makeCodigo(numero, siglaPerfil){
+  return `OT${numero}${siglaPerfil}`;
+}
+
+export const corPrincipal = '#8B0000'; // vermelho escuro
+
+export const dadosGerais = {
+  nome: '',
+  telefone: '',
+  cpf: '',
+  armacao: '',
+  lente: '',
+  grau: {
+    OE: { esf: '', cil: '', eixo: '', dnp: '', adicao: '' },
+    OD: { esf: '', cil: '', eixo: '', dnp: '', adicao: '' }
+  },
+  observacao: '',
+  previsaoEntrega: ''
+};
+
+export const viaLoja = {
+  valorArmacao: 0,
+  valorLente: 0,
+  get valorTotal(){
+    return this.valorArmacao + this.valorLente;
+  }
+};
+
+export const garantia = {
+  visivelEm: ['cliente', 'loja'],
+  texto: '' // texto definido pelo administrador
+};
+
+export default {
+  makeCodigo,
+  corPrincipal,
+  dadosGerais,
+  viaLoja,
+  garantia
+};


### PR DESCRIPTION
## Summary
- add configuration module for optic service orders
- expose optic service order from OS features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a60a31e0488333b7ed01018be73628