### PR TITLE
Refine print layout and Kanban styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -984,7 +984,7 @@ function renderOS() {
     <div class="os-kanban" id="osKanban">
       ${cols.map(([k,label])=>{
         const cls={loja:'col-kanban--loja',oficina:'col-kanban--oficina',aguardando:'col-kanban--aguardo',completo:'col-kanban--completo'}[k];
-        return `<div class="kanban-col ${cls}" data-status="${k}"><div class="kanban-header"><h3>${label} (<span class="count">0</span>)</h3></div><div class="cards"></div><div class="kanban-footer"><button class="kanban-prev" disabled>Anterior</button><span class="sep">|</span><span class="page-info">1 / 1</span><span class="sep">|</span><button class="kanban-next" disabled>Próxima</button></div></div>`;
+        return `<div class="kanban-col ${cls}" data-status="${k}"><div class="kanban-header"><h3>${label} <span class="count">0</span></h3></div><div class="cards"></div><div class="kanban-footer"><button class="kanban-prev" disabled>Anterior</button><span class="sep">|</span><span class="page-info">1 / 1</span><span class="sep">|</span><button class="kanban-next" disabled>Próxima</button></div></div>`;
       }).join('')}
     </div>
   </section>`;
@@ -2832,8 +2832,12 @@ function renderOSKanban(){
       card.dataset.id=os.id;
       card.tabIndex=0;
       const dates=[];
-      if(os.campos.dataOficina) dates.push(`<div><strong>Data de Oficina:</strong> ${formatDateDDMMYYYY(os.campos.dataOficina)}</div>`);
-      if(os.campos.dataEntrega) dates.push(`<div><strong>Previsão de entrega:</strong> ${formatDateDDMMYYYY(os.campos.dataEntrega)}</div>`);
+      if(os.campos.dataOficina) {
+        dates.push(`<div>Data de Oficina: ${formatDateDDMMYYYY(os.campos.dataOficina)}</div>`);
+      }
+      if(os.campos.dataEntrega) {
+        dates.push(`<div class="previsao">Previsão de entrega: ${formatDateDDMMYYYY(os.campos.dataEntrega)}</div>`);
+      }
       card.innerHTML=`<div class="os-card-top"><div class="os-card-title"><span class="os-code">${os.codigo}</span> <strong>${os.campos.cliente}</strong> - ${os.campos.telefone}</div>`+
         `<div class="os-card-actions">`+
         `<button class="os-action btn-os-imprimir" title="Imprimir" aria-label="Imprimir" data-id="${os.id}">${ICON_PRINTER}</button>`+
@@ -2881,11 +2885,17 @@ function printOS(os){
     const logo = perfilInfo.logo ?
       `<img src="${perfilInfo.logo}" alt="Logo" class="logo-img">` :
       `<div class="logo-placeholder">Logo</div>`;
-    const nome = perfilInfo.nome ? `<div class="loja-nome">${perfilInfo.nome}</div>` : '';
     const contato = showContacts ?
       `<div class="os-print-contact">${perfilInfo.telefone?`<div>${perfilInfo.telefone}</div>`:''}${perfilInfo.endereco?`<div>${perfilInfo.endereco}</div>`:''}${perfilInfo.instagram?`<div><a href="https://instagram.com/${perfilInfo.instagram.replace(/^@/, '')}" target="_blank">${perfilInfo.instagram}</a></div>`:''}</div>` : '';
+    const dates=[];
+    if(campos.dataOficina) {
+      dates.push(`<div>Data de Oficina: ${formatDateDDMMYYYY(campos.dataOficina)}</div>`);
+    }
+    if(campos.dataEntrega) {
+      dates.push(`<div class="previsao">Previsão de entrega: ${formatDateDDMMYYYY(campos.dataEntrega)}</div>`);
+    }
     let html=`<section class="os-print-via">`+
-      `<div class="os-print-header">${logo}${nome}${contato}</div>`+
+      `<div class="os-print-header">${logo}${contato}</div>`+
       `<div class="os-print-head ${tipo}"><span class="code">${os.codigo}</span> <span class="tipo">${tipoLabel}</span></div>`+
       `<h2>${titulo}</h2>`+
       `<div class="os-print-body">`+
@@ -2903,10 +2913,7 @@ function printOS(os){
       `${opts.notaOficina&&campos.notaOficina?`<div><strong>Nota para Oficina:</strong> ${campos.notaOficina}</div>`:''}`+
       `${opts.notaLoja&&campos.notaLoja?`<div><strong>Nota para Loja:</strong> ${campos.notaLoja}</div>`:''}`+
       `</div>`+
-      `<div class="os-print-dates">`+
-      `${campos.dataOficina?`<div><strong>Data de Oficina:</strong> ${formatDateDDMMYYYY(campos.dataOficina)}</div>`:''}`+
-      `${campos.dataEntrega?`<div><strong>Previsão de entrega:</strong> ${formatDateDDMMYYYY(campos.dataEntrega)}</div>`:''}`+
-      `</div>`+
+      `${dates.length?`<div class="os-print-dates">${dates.join('')}</div>`:''}`+
       `<footer class="os-print-footer"><div class="assinatura"></div><div class="assinatura"></div></footer>`+
       `</section>`;
     return html;
@@ -2930,7 +2937,8 @@ function printOS(os){
   .os-print-head.reloj{background:#183C7A;}
   .os-print-head.joia{background:#C99700;}
   .os-print-head.optica{background:#8B1E1E;}
-  .os-print-dates{margin-top:12px;font-weight:bold;}
+  .os-print-dates{margin-top:12px;}
+  .os-print-dates .previsao{margin-top:8px;font-weight:bold;}
   .os-print-footer{margin-top:24px;display:flex;gap:12mm;}
   .os-print-footer .assinatura{border-top:1px solid #000;height:40px;flex:1;text-align:center;}
   .os-print-footer .assinatura:after{content:"Assinatura";position:relative;top:8px;display:block;font-size:10pt;}

--- a/style.css
+++ b/style.css
@@ -314,18 +314,19 @@ input[name="telefone"] { width:18ch; }
 .os-filters{display:flex; flex-wrap:wrap; gap:8px;}
 .os-filters input, .os-filters select{height:var(--control-height);}
 .os-kanban { display: flex; gap: 1rem; align-items: flex-start; }
-.os-kanban .kanban-col { flex: 1; border: 1px solid var(--color-border); border-radius: var(--radius-lg); min-height: 200px; padding: 0; display:flex; flex-direction:column; }
+.os-kanban .kanban-col { flex: 1; border: 1px solid var(--color-border); border-radius: var(--radius-lg); min-height: 200px; padding: 0; display:flex; flex-direction:column; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,0.05); }
 .os-kanban .kanban-col .kanban-header { text-align:center; font-weight:bold; font-size:1.125rem; padding:0.5rem; border-bottom:1px solid var(--color-border); }
 .os-kanban .kanban-col .kanban-header h3 { margin:0; font-size:inherit; font-weight:inherit; }
+.os-kanban .kanban-col .kanban-header .count{margin-left:4px;font-weight:normal;}
 .os-kanban .kanban-col .cards { flex:1; padding:0.5rem; }
 .os-kanban .kanban-col .kanban-footer { border-top:1px solid var(--color-border); padding:0.5rem; display:flex; justify-content:center; align-items:center; gap:0.5rem; font-size:0.875rem; }
 .os-kanban .kanban-col .kanban-footer button { background:none; border:none; cursor:pointer; color:var(--color-text); }
 .os-kanban .kanban-col .kanban-footer button:disabled { opacity:0.5; cursor:default; }
 .os-kanban .kanban-col .kanban-footer .sep{opacity:0.6;}
-.col-kanban--loja{background-color:var(--kanban-loja);}
-.col-kanban--oficina{background-color:var(--kanban-oficina);}
-.col-kanban--aguardo{background-color:var(--kanban-aguardo);}
-.col-kanban--completo{background-color:var(--kanban-completo);}
+.col-kanban--loja{background-color:#fff;}
+.col-kanban--oficina{background-color:#fff;}
+.col-kanban--aguardo{background-color:#fff;}
+.col-kanban--completo{background-color:#fff;}
 .os-card { border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: 0.5rem; overflow: hidden; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,0.05); }
 .os-card-top { padding:4px 8px; font-weight:bold; color:#fff; display:flex; justify-content:space-between; align-items:center; }
 .os-card-title{flex:1;}
@@ -337,7 +338,8 @@ input[name="telefone"] { width:18ch; }
 .os-card.joia .os-card-top{ background: var(--os-joia-color); }
 .os-card.optica .os-card-top{ background: var(--os-optica-color); }
 .os-card-body { padding: 4px 8px; font-size: 0.875rem; }
-.os-card-dates{margin-top:8px;font-weight:bold;}
+.os-card-dates{margin-top:8px;}
+.os-card-dates .previsao{margin-top:4px;font-weight:bold;}
 .badge{display:inline-block;padding:2px 4px;border-radius:var(--radius-sm);font-size:0.75rem;}
 .os-card .badge{color:#fff;}
 


### PR DESCRIPTION
## Summary
- Ensure Kanban columns use clean white cards with subtle shadow and show OS counts next to titles.
- Display Previsão de entrega as a bold final line with spacing in cards and printed vias.
- Simplify print headers to show only the logo on the left and optional contact info on the right.

## Testing
- `npm test`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6106264b0833388f3589a6ee7887e