### PR TITLE
feat: kanban refresh and client fields update

### DIFF
--- a/style.css
+++ b/style.css
@@ -315,18 +315,18 @@ input[name="telefone"] { width:18ch; }
 .os-filters input, .os-filters select{height:var(--control-height);}
 .os-kanban { display: flex; gap: 1rem; align-items: flex-start; }
 .os-kanban .kanban-col { flex: 1; border: 1px solid var(--color-border); border-radius: var(--radius-lg); min-height: 200px; padding: 0; display:flex; flex-direction:column; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,0.05); }
-.os-kanban .kanban-col .kanban-header { text-align:center; font-weight:bold; font-size:1.125rem; padding:0.5rem; border-bottom:1px solid var(--color-border); }
+.os-kanban .kanban-col .kanban-header { text-align:center; font-weight:bold; font-size:1.25rem; padding:0.5rem; border-bottom:1px solid var(--color-border); display:flex; flex-direction:column; align-items:center; }
 .os-kanban .kanban-col .kanban-header h3 { margin:0; font-size:inherit; font-weight:inherit; }
-.os-kanban .kanban-col .kanban-header .count{margin-left:4px;font-weight:normal;}
+.os-kanban .kanban-col .kanban-header .count{margin-top:0.25rem;font-weight:bold;font-size:1rem;}
 .os-kanban .kanban-col .cards { flex:1; padding:0.5rem; }
 .os-kanban .kanban-col .kanban-footer { border-top:1px solid var(--color-border); padding:0.5rem; display:flex; justify-content:center; align-items:center; gap:0.5rem; font-size:0.875rem; }
 .os-kanban .kanban-col .kanban-footer button { background:none; border:none; cursor:pointer; color:var(--color-text); }
 .os-kanban .kanban-col .kanban-footer button:disabled { opacity:0.5; cursor:default; }
 .os-kanban .kanban-col .kanban-footer .sep{opacity:0.6;}
-.col-kanban--loja{background-color:#fff;}
-.col-kanban--oficina{background-color:#fff;}
-.col-kanban--aguardo{background-color:#fff;}
-.col-kanban--completo{background-color:#fff;}
+.os-kanban .kanban-col.col-kanban--loja{background-color:#e8f5e9;}
+.os-kanban .kanban-col.col-kanban--oficina{background-color:#fff3e0;}
+.os-kanban .kanban-col.col-kanban--aguardo{background-color:#e3f2fd;}
+.os-kanban .kanban-col.col-kanban--completo{background-color:#e8f5e9;}
 .os-card { border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: 0.5rem; overflow: hidden; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,0.05); }
 .os-card-top { padding:4px 8px; font-weight:bold; color:#fff; display:flex; justify-content:space-between; align-items:center; }
 .os-card-title{flex:1;}


### PR DESCRIPTION
## Summary
- restyle kanban columns with color themes and clearer headers
- allow creating optical service orders and compact OS print layout
- add client gender and interests fields with persistence

## Testing
- `node --check script.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61429913083338e475ee799838248