### PR TITLE
Render client details after saving

### DIFF
--- a/script.js
+++ b/script.js
@@ -2697,6 +2697,7 @@ function closePurchaseModal(){
 
 function refreshUI(){
   window.renderClientsTable?.();
+  window.renderClientDetail?.();
   renderSelectedPurchaseDetails?.();
   renderCalendarMonth?.();
   renderDashboard?.();


### PR DESCRIPTION
## Summary
- Call `renderClientDetail` during UI refresh so client details show after closing the modal

## Testing
- `npm test`
- `node -e "..."`

------
https://chatgpt.com/codex/tasks/task_e_68a61a9f3c008333a61183483daa392a