### PR TITLE
feat(clientes): add menu bar and reserved slots

### DIFF
--- a/script.js
+++ b/script.js
@@ -961,13 +961,21 @@ function renderCalendario() {
 }
 function renderClientes() {
   return `
+  <div class="balloon balloon--menu-bar clientes-menu">
+    <div class="search-wrapper"><span class="icon">${iconSearch}</span><input id="clientSearch" type="search" placeholder="Pesquisar clientes…" aria-label="Pesquisar clientes" /></div>
+    <button id="tagMenuBtn" type="button" class="btn-dropdown">Etiquetas ▾</button>
+  </div>
+  <div class="clientes-reserved">
+    <div class="balloon"><small>Reservado</small></div>
+    <div class="balloon"><small>Reservado</small></div>
+    <div class="balloon"><small>Reservado</small></div>
+    <div class="balloon"><small>Reservado</small></div>
+  </div>
   <div class="card-grid">
     <div class="card" data-card-id="lista-clientes" data-colspan="6">
       <div class="card-header">
         <div class="card-head">Lista de Clientes</div>
         <div class="list-toolbar clients-toolbar">
-            <div class="search-wrap"><span class="icon">${iconSearch}</span><input id="clientSearch" class="search-input" placeholder="Pesquisar clientes…" aria-label="Pesquisar clientes" /></div>
-            <button id="tagMenuBtn" type="button" class="btn-dropdown">Etiquetas ▾</button>
             <button id="addClientBtn" class="btn-icon btn-plus add-cliente" data-action="client:new" aria-label="Adicionar" title="Adicionar">${iconPlus}</button>
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -375,6 +375,30 @@ input[name="telefone"] { width:18ch; }
   box-shadow: 0 0 0 2px var(--color-primary), var(--balloon-shadow);
 }
 
+/* Clients page layout */
+.clientes-menu,
+.clientes-reserved {
+  margin-bottom: 1rem;
+}
+
+.clientes-menu .search-wrapper {
+  flex: 1;
+}
+
+.clientes-menu .btn-dropdown {
+  height: var(--control-height);
+}
+
+.clientes-reserved {
+  display: flex;
+  gap: var(--balloon-gap);
+}
+
+.clientes-reserved > .balloon {
+  flex: 1;
+  min-height: 80px;
+}
+
 @media (max-width:600px) {
   .balloon {
     padding: var(--space-sm);


### PR DESCRIPTION
## Summary
- add menu bar with search and tag filter to clientes page
- add four reserved balloon placeholders above clients list
- style clients page balloons and layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72c8085108333ba2ccf7dd9cf5460