### PR TITLE
feat: update clients and calendar menu bars

### DIFF
--- a/script.js
+++ b/script.js
@@ -853,7 +853,7 @@ function renderCalendarMenuBar(){
         <button class="btn btn-cal-desfalques" style="display:none">Desfalques</button>
       </div>
       <div class="menu-widgets">
-        <div class="mini-widget">
+        <div class="mini-widget mini-blue">
           <div class="mini-title">Contatos</div>
           <div class="mini-split">
             <div class="mini-part">
@@ -866,7 +866,7 @@ function renderCalendarMenuBar(){
             </div>
           </div>
         </div>
-        <div class="mini-widget">
+        <div class="mini-widget mini-yellow">
           <div class="mini-title">O.S Aguardando</div>
           <div class="mini-triple">
             <div class="mini-part">
@@ -883,7 +883,7 @@ function renderCalendarMenuBar(){
             </div>
           </div>
         </div>
-        <div class="mini-widget">
+        <div class="mini-widget mini-yellow">
           <div class="mini-title">O.S para Hoje</div>
           <div class="mini-value" data-stat="os-hoje">0</div>
         </div>
@@ -919,8 +919,10 @@ function updateCalendarMenuBar(){
   let osHoje=0;
   list.forEach(os=>{
     const tipo=os.tipo||'reloj';
-    if(os.status==='aguardando') aguardando[tipo]=(aguardando[tipo]||0)+1;
-    if(os.campos?.dataOficina===todayISO) osHoje++;
+    if(os.status==='oficina'){
+      aguardando[tipo]=(aguardando[tipo]||0)+1;
+      if(os.campos?.dataOficina===todayISO) osHoje++;
+    }
   });
   bar.querySelector('[data-stat="os-aguardando-o"]').textContent=aguardando.optica||0;
   bar.querySelector('[data-stat="os-aguardando-r"]').textContent=aguardando.reloj||0;
@@ -967,23 +969,26 @@ function renderCalendario() {
 function renderClientes() {
   return `
   <div class="balloon balloon--menu-bar clientes-menu">
-    <div class="search-wrapper"><span class="icon">${iconSearch}</span><input id="clientSearch" type="search" placeholder="Pesquisar clientes…" aria-label="Pesquisar clientes" /></div>
-    <button id="tagMenuBtn" type="button" class="btn-dropdown">Etiquetas ▾</button>
-  </div>
-  <div class="clientes-reserved">
-    <div class="balloon"><small>Reservado</small></div>
-    <div class="balloon"><small>Reservado</small></div>
-    <div class="balloon"><small>Reservado</small></div>
-    <div class="balloon"><small>Reservado</small></div>
+    <div class="mini-card"><small>Reservado</small></div>
+    <div class="mini-card"><small>Reservado</small></div>
+    <div class="mini-card"><small>Reservado</small></div>
+    <div class="mini-card"><small>Reservado</small></div>
   </div>
   <div class="card-grid">
     <div class="card" data-card-id="lista-clientes" data-colspan="6">
       <div class="card-header">
         <div class="card-head">Lista de Clientes</div>
         <div class="list-toolbar clients-toolbar">
-            <button id="addClientBtn" class="btn-icon btn-plus add-cliente" data-action="client:new" aria-label="Adicionar" title="Adicionar">${iconPlus}</button>
+          <div class="search-wrap">
+            <span class="icon">${iconSearch}</span>
+            <input id="clientSearch" class="search-input" type="search" placeholder="Pesquisar clientes…" aria-label="Pesquisar clientes" />
           </div>
+          <div class="filters-wrap">
+            <button id="tagMenuBtn" type="button" class="btn-dropdown">Etiquetas ▾</button>
+          </div>
+          <button id="addClientBtn" class="btn-icon btn-plus add-cliente" data-action="client:new" aria-label="Adicionar" title="Adicionar">${iconPlus}</button>
         </div>
+      </div>
       <div class="card-body table-wrapper">
         <table class="table table-clients">
           <thead>

--- a/style.css
+++ b/style.css
@@ -374,27 +374,31 @@ input[name="telefone"] { width:18ch; }
 }
 
 /* Clients page layout */
-.clientes-menu,
-.clientes-reserved {
+.clientes-menu {
   margin-bottom: 1rem;
-}
-
-.clientes-menu .search-wrapper {
-  flex: 1;
-}
-
-.clientes-menu .btn-dropdown {
-  height: var(--control-height);
-}
-
-.clientes-reserved {
-  display: flex;
+  display: grid;
   gap: var(--balloon-gap);
+  grid-template-columns: repeat(4,1fr);
+}
+.clientes-menu .mini-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  min-height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
 }
 
-.clientes-reserved > .balloon {
-  flex: 1;
-  min-height: 80px;
+@media (max-width:1199px) {
+  .clientes-menu {
+    grid-template-columns: repeat(2,1fr);
+  }
+}
+@media (max-width:767px) {
+  .clientes-menu {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width:600px) {
@@ -771,15 +775,17 @@ input[name="telefone"] { width:18ch; }
 .segmented [aria-pressed="false"] { background:var(--neutral-200); color:var(--color-text); }
 
 /* ===== Calendar Menu Bar ===== */
-.calendar-menu-bar { background:var(--surface); border-radius:var(--radius-lg); padding:0.75rem; display:grid; grid-template-columns:max-content 1fr; gap:1rem; align-items:center; }
+.calendar-menu-bar { background:var(--surface); border-radius:var(--radius-lg); padding:1rem; display:grid; grid-template-columns:max-content 1fr; gap:1rem; align-items:center; }
 .calendar-menu-bar .menu-actions { display:flex; gap:0.5rem; }
 .calendar-menu-bar .menu-widgets { display:grid; grid-template-columns:repeat(auto-fit,minmax(90px,1fr)); gap:0.5rem; }
-.calendar-menu-bar .mini-widget { background:var(--surface); border:1px solid var(--color-border); border-radius:var(--radius-md); padding:0.25rem; display:flex; flex-direction:column; align-items:center; justify-content:center; min-width:80px; box-shadow:var(--card-shadow); }
-.calendar-menu-bar .mini-title { font-weight:700; font-size:0.75rem; margin-bottom:4px; text-align:center; white-space:nowrap; }
-.calendar-menu-bar .mini-value { font-weight:700; text-align:center; }
+.calendar-menu-bar .mini-widget { background:var(--surface); border:1px solid var(--color-border); border-radius:var(--radius-md); padding:0.5rem; display:flex; flex-direction:column; align-items:center; justify-content:center; min-width:80px; box-shadow:var(--card-shadow); }
+.calendar-menu-bar .mini-title { font-weight:700; font-size:0.875rem; margin-bottom:4px; text-align:center; white-space:nowrap; }
+.calendar-menu-bar .mini-value { font-weight:700; text-align:center; font-size:1.25rem; }
 .calendar-menu-bar .mini-split, .calendar-menu-bar .mini-triple { display:flex; gap:0.5rem; }
 .calendar-menu-bar .mini-part { display:flex; flex-direction:column; align-items:center; }
-.calendar-menu-bar .mini-label { font-size:0.625rem; }
+.calendar-menu-bar .mini-label { font-size:0.75rem; }
+.calendar-menu-bar .mini-widget.mini-blue { background:#e3f2fd; }
+.calendar-menu-bar .mini-widget.mini-yellow { background:#fff8e1; }
 .calendar-menu-bar .mini-empty { border:1px dashed var(--color-border); box-shadow:none; }
 @media (max-width:768px){
   .calendar-menu-bar{ grid-template-columns:1fr; }


### PR DESCRIPTION
## Summary
- add responsive placeholder card container to clients page
- expand calendar menu bar with colored metrics for contacts and O.S.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7331ff1448333b9738e347cae0f6a