### PR TITLE
Refine OS pin and print layouts

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,7 +140,7 @@ a { color: inherit; text-decoration: none; }
   cursor: pointer;
   position: relative;
   color:#ccc;
-  border-left:4px solid transparent;
+  border-left:none;
 }
 .nav-item .icon { width:18px; height:18px; display:inline-flex; flex-shrink:0; }
 .nav-item .icon svg { width:100%; height:100%; }
@@ -149,7 +149,6 @@ a { color: inherit; text-decoration: none; }
   background: #2A2F37;
   color: #fff;
   font-weight: 600;
-  border-left-color: var(--color-primary);
 }
 .nav-item:hover { background: #2A2F37; }
 .nav-item:focus {
@@ -445,7 +444,7 @@ input[name="telefone"] { width:18ch; }
 .os-kanban .kanban-col{border:1px solid var(--color-border);border-radius:var(--radius-lg);min-height:420px;padding:0;display:flex;flex-direction:column;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,0.05);}
 .os-kanban .kanban-col .kanban-header{text-align:center;font-weight:bold;font-size:1.25rem;padding:0.5rem;border-bottom:1px solid var(--color-border);}
 .os-kanban .kanban-col .kanban-header h3{margin:0;font-size:inherit;font-weight:inherit;}
-.os-kanban .kanban-col .kanban-header .count{font-weight:normal;}
+.os-kanban .kanban-col .kanban-header .count{display:inline-flex;align-items:center;justify-content:center;background:#fff;color:#000;font-weight:bold;border-radius:50%;width:28px;height:28px;margin-left:4px;}
 .os-kanban .kanban-col .cards{flex:1;padding:0.5rem;display:grid;grid-template-columns:1fr;gap:0.5rem;align-content:flex-start;min-height:300px;}
 .os-kanban .kanban-col .cards .os-card{margin:0;}
 .os-kanban .kanban-col .kanban-footer { border-top:1px solid var(--color-border); padding:0.5rem; display:flex; justify-content:center; align-items:center; gap:0.5rem; font-size:0.875rem; }
@@ -494,13 +493,14 @@ input[name="telefone"] { width:18ch; }
 .os-card-actions .btn-os-pin{width:16px;height:16px;border-radius:50%;padding:0;}
 .os-card-actions .btn-os-pin.pin-blue{background:#1e88e5;}
 .os-card-actions .btn-os-pin.pin-green{background:#43a047;}
+.os-card-actions .btn-os-pin.pin-orange{background:#ff9800;}
 .os-kanban .kanban-col.drag-over { outline:2px dashed var(--os-reloj-color); }
 .os-type-filter{display:flex;gap:8px;border:none;}
 .os-type-filter .filter-btn{padding:0.5rem 1rem;border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--surface);cursor:pointer;}
 .os-type-filter .filter-btn.active{background:var(--color-primary);color:#fff;}
 .os-type-filter .filter-btn:focus{outline:2px solid var(--color-primary);outline-offset:-2px;}
-.os-type-choices{display:flex;gap:8px;flex-wrap:wrap;}
-.os-type{padding:12px;border:0;border-radius:var(--radius-md);color:#fff;cursor:pointer;}
+.os-type-choices{display:flex;gap:16px;flex-wrap:wrap;justify-content:center;}
+.os-type{padding:16px 24px;border:0;border-radius:var(--radius-md);color:#fff;cursor:pointer;flex:1 1 120px;text-align:center;font-size:1rem;max-width:200px;}
 .os-type-reloj{background:var(--os-reloj-color);}
 .os-type-joia{background:var(--os-joia-color);}
 .os-type-optica{background:var(--os-optica-color);}


### PR DESCRIPTION
## Summary
- highlight pinned OS entries in orange and show counts as circular badges
- center OS type buttons and update sidebar/print styles
- reduce print headers, add signature space, and label vias for A4 pages

## Testing
- `node --check script.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78793e5b08333b399c649f9140097