### PR TITLE
Add calendar pickup widget and refine navigation styles

### DIFF
--- a/script.js
+++ b/script.js
@@ -922,6 +922,23 @@ function renderCalendarMenuBar(){
           </div>
         </div>
         <div class="mini-widget mini-yellow">
+          <div class="mini-title">Aguardando Retirada</div>
+          <div class="mini-triple">
+            <div class="mini-part">
+              <div class="mini-value" data-stat="os-retirada-o">0</div>
+              <div class="mini-label">Óptica</div>
+            </div>
+            <div class="mini-part">
+              <div class="mini-value" data-stat="os-retirada-r">0</div>
+              <div class="mini-label">Relógio</div>
+            </div>
+            <div class="mini-part">
+              <div class="mini-value" data-stat="os-retirada-j">0</div>
+              <div class="mini-label">Jóias</div>
+            </div>
+          </div>
+        </div>
+        <div class="mini-widget mini-yellow">
           <div class="mini-title">O.S para Hoje</div>
           <div class="mini-value" data-stat="os-hoje">0</div>
         </div>
@@ -954,6 +971,7 @@ function updateCalendarMenuBar(){
   const list=loadOSList();
   const todayISO=formatDateYYYYMMDD(new Date());
   const aguardando={reloj:0, joia:0, optica:0};
+  const aguardandoRetirada={reloj:0, joia:0, optica:0};
   let osHoje=0;
   list.forEach(os=>{
     const tipo=os.tipo||'reloj';
@@ -961,10 +979,16 @@ function updateCalendarMenuBar(){
       aguardando[tipo]=(aguardando[tipo]||0)+1;
       if(os.campos?.dataOficina===todayISO) osHoje++;
     }
+    if(os.status==='aguardando'){
+      aguardandoRetirada[tipo]=(aguardandoRetirada[tipo]||0)+1;
+    }
   });
   bar.querySelector('[data-stat="os-aguardando-o"]').textContent=aguardando.optica||0;
   bar.querySelector('[data-stat="os-aguardando-r"]').textContent=aguardando.reloj||0;
   bar.querySelector('[data-stat="os-aguardando-j"]').textContent=aguardando.joia||0;
+  bar.querySelector('[data-stat="os-retirada-o"]').textContent=aguardandoRetirada.optica||0;
+  bar.querySelector('[data-stat="os-retirada-r"]').textContent=aguardandoRetirada.reloj||0;
+  bar.querySelector('[data-stat="os-retirada-j"]').textContent=aguardandoRetirada.joia||0;
   bar.querySelector('[data-stat="os-hoje"]').textContent=osHoje;
 }
 
@@ -4167,23 +4191,25 @@ document.addEventListener('DOMContentLoaded', async () => {
     if(item.classList.contains('has-submenu')){
       item.addEventListener('click', () => {
         const expanded=item.dataset.expanded==='true';
-        const next=!expanded;
-        toggleSubmenu(item,next);
-        if(next){
-          const def=item.dataset.defaultRoute;
-          if(def) location.hash = '#/'+def;
+        const def=item.dataset.defaultRoute;
+        if(expanded && def && currentRoute===def){
+          toggleSubmenu(item,false);
+          return;
         }
+        toggleSubmenu(item,true);
+        if(def) location.hash = '#/'+def;
       });
       item.addEventListener('keydown', e => {
         if(e.key==='Enter' || e.key===' '){
           e.preventDefault();
           const expanded=item.dataset.expanded==='true';
-          const next=!expanded;
-          toggleSubmenu(item,next);
-          if(next){
-            const def=item.dataset.defaultRoute;
-            if(def) location.hash = '#/'+def;
+          const def=item.dataset.defaultRoute;
+          if(expanded && def && currentRoute===def){
+            toggleSubmenu(item,false);
+            return;
           }
+          toggleSubmenu(item,true);
+          if(def) location.hash = '#/'+def;
         }
       });
     } else {

--- a/style.css
+++ b/style.css
@@ -15,6 +15,8 @@
   --radius-lg: 12px;
   --cell-min-h: 72px;
   --sidebar-w: 248px;
+  --sidebar-bg: #1F232A;
+  --sidebar-sub-bg: #272D36;
   --neutral-150: #d8d8d8;
   --neutral-200: #bfbfbf;
   --text-strong: var(--color-text);
@@ -57,6 +59,8 @@ html.theme-dark {
   --color-border: #333333;
   --color-accent: #cccccc;
   --color-primary: #66bb6a;
+  --sidebar-bg: #151922;
+  --sidebar-sub-bg: #1f2530;
   --neutral-150: #2a2a2a;
   --neutral-200: #333333;
   --text-strong: var(--color-text);
@@ -88,7 +92,7 @@ a { color: inherit; text-decoration: none; }
   position: sticky;
   top: 0;
   align-self: stretch;
-  background: #1F232A;
+  background: var(--sidebar-bg);
   border-right: none;
   border-radius: 0;
   display: flex;
@@ -196,6 +200,7 @@ a { color: inherit; text-decoration: none; }
 .nav-subitem:hover { background: #2A2F37; }
 .nav-item.has-submenu.is-expanded[data-root="clientes"] ~ .nav-subitem[data-parent="clientes"] {
   display: flex;
+  background: var(--sidebar-sub-bg);
 }
 .topbar {
   position: sticky;
@@ -838,9 +843,41 @@ input[name="telefone"] { width:18ch; }
 .calendario-wrapper { display:flex; flex-direction:column; gap:1rem; --neutral-100: var(--color-border); --green-600: var(--color-primary); --red-600: #c62828; --red-400: #e57373; --card-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .cal-toolbar { display:flex; flex-wrap:wrap; align-items:center; justify-content:space-between; gap:1rem; }
 .cal-right { display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; }
-.cal-nav { display:flex; align-items:center; gap:0.5rem; }
-.cal-nav button { width:48px; height:48px; border-radius:var(--radius-md); display:grid; place-items:center; padding:0; }
-.cal-nav .cal-mes { text-align:center; font-size:1.5rem; margin:0 0.5rem; }
+.cal-nav {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  position:relative;
+  padding:0 3.5rem;
+  width:clamp(240px, 30vw, 320px);
+  max-width:100%;
+}
+.cal-nav button {
+  width:48px;
+  height:48px;
+  border-radius:var(--radius-md);
+  display:grid;
+  place-items:center;
+  padding:0;
+}
+.cal-nav .cal-prev,
+.cal-nav .cal-next {
+  position:absolute;
+  top:50%;
+  transform:translateY(-50%);
+}
+.cal-nav .cal-prev { left:0; }
+.cal-nav .cal-next { right:0; }
+.cal-nav .cal-mes {
+  text-align:center;
+  font-size:1.5rem;
+  margin:0;
+  flex:0 0 auto;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  padding:0 0.25rem;
+}
 .cal-toolbar button, .cal-toolbar select, .cal-toolbar input { font:inherit; height:36px; }
 .cal-toolbar .btn { padding:0 0.75rem; }
 .btn-cal-eventos { background:var(--accent-orange); color:#fff; }


### PR DESCRIPTION
## Summary
- add an "Aguardando Retirada" widget to the calendário dashboard and populate it with kanban counts
- ensure the Clientes menu button navigates directly to Visão Geral while preserving collapse behaviour when already there
- lighten the expanded submenu background and keep the calendar month navigation arrows fixed in place

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cad052e0a08333a01d765a9314fd71