### PR TITLE
Adjust dashboard cards and sidebar layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -146,11 +146,12 @@ a { color: inherit; text-decoration: none; }
   margin: 0;
 }
 .nav-item {
-  height: 40px;
-  display: flex;
+  min-height: 44px;
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
   align-items: center;
   gap: 10px;
-  padding: 0 16px 0 24px;
+  padding: 0 16px 0 18px;
   justify-content: flex-start;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -159,14 +160,14 @@ a { color: inherit; text-decoration: none; }
   border-left: none;
   margin: 0 16px;
   transition: background 0.2s ease, color 0.2s ease;
+  box-sizing: border-box;
 }
 .nav-item .icon {
   width: 24px;
   height: 24px;
-  display: inline-flex;
+  display: grid;
+  place-items: center;
   flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
 }
 .nav-item .icon svg { width:100%; height:100%; }
 .nav-item .label,
@@ -177,15 +178,19 @@ a { color: inherit; text-decoration: none; }
   display: inline-block;
   transition: transform 0.2s ease;
   transform-origin: left center;
+  font-size: 0.95rem;
+  line-height: 1.2;
 }
 .sidebar:not(.is-expanded) .nav-item,
 .sidebar:not(.is-expanded) .nav-subitem {
   margin-inline: 12px;
-  padding-left: 24px;
-  padding-right: 16px;
+  padding-left: 18px;
+  padding-right: 18px;
 }
 .sidebar:not(.is-expanded) .nav-item {
-  justify-content: flex-start;
+  justify-content: center;
+  grid-template-columns: 24px;
+  gap: 0;
 }
 .sidebar:not(.is-expanded) .nav-item .label,
 .sidebar:not(.is-expanded) .nav-subitem .label,
@@ -198,7 +203,7 @@ a { color: inherit; text-decoration: none; }
 .sidebar.is-expanded .nav-item,
 .sidebar.is-expanded .nav-subitem {
   justify-content: flex-start;
-  padding-left: 24px;
+  padding-left: 18px;
   padding-right: 16px;
   margin-inline: 16px;
 }
@@ -232,13 +237,15 @@ a { color: inherit; text-decoration: none; }
 }
 .nav-item.has-submenu { position: relative; }
 .nav-item.has-submenu .submenu-caret {
-  margin-left: auto;
+  margin-left: 0;
+  justify-self: end;
   font-size: 0.75rem;
   transform: rotate(0deg);
   transition: transform 0.2s ease;
 }
 .nav-item.has-submenu.is-expanded .submenu-caret { transform: rotate(90deg); }
 .nav-subitem {
+  display: flex;
   align-items: center;
   gap: 8px;
   padding: 0 16px 0 56px;
@@ -1082,14 +1089,13 @@ input[name="telefone"] { width:18ch; }
 .segmented [aria-pressed="false"] { background:var(--neutral-200); color:var(--color-text); }
 
 /* ===== Calendar Menu Bar ===== */
-.calendar-menu-bar { background:var(--surface); border-radius:var(--radius-lg); padding:1rem; display:grid; grid-template-columns:minmax(0,max-content) minmax(0,1fr); gap:1rem; align-items:center; margin-bottom:1.5rem; width:100%; box-sizing:border-box; }
-.calendar-menu-bar .menu-actions { display:flex; gap:0.5rem; align-self:start; }
-.calendar-menu-bar .menu-widgets { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:0.75rem; align-items:stretch; }
-.calendar-menu-bar .mini-widget { background:var(--surface); border:1px solid var(--color-border); border-radius:var(--radius-md); padding:0.85rem; display:flex; flex-direction:column; align-items:center; justify-content:center; min-width:120px; min-height:110px; box-shadow:var(--card-shadow); }
-.calendar-menu-bar .mini-title { font-weight:700; font-size:1rem; margin-bottom:4px; text-align:center; white-space:nowrap; }
+.calendar-menu-bar { background:var(--surface); border-radius:var(--radius-lg); padding:var(--space-md); display:flex; flex-direction:column; gap:var(--space-md); align-items:stretch; margin-bottom:1.5rem; width:100%; box-sizing:border-box; }
+.calendar-menu-bar .menu-actions { display:flex; flex-wrap:wrap; gap:var(--space-sm); align-items:center; align-self:flex-start; }
+.calendar-menu-bar .menu-widgets { display:flex; flex-wrap:wrap; gap:var(--space-md); align-items:stretch; justify-content:flex-start; width:100%; }
+.calendar-menu-bar .mini-widget { background:var(--surface); border:1px solid var(--color-border); border-radius:var(--radius-md); padding:var(--space-md); display:flex; flex-direction:column; align-items:center; justify-content:center; min-width:180px; flex:1 1 200px; min-height:140px; box-shadow:var(--card-shadow); box-sizing:border-box; overflow:hidden; text-align:center; gap:var(--space-sm); }
+.calendar-menu-bar .mini-title { font-weight:700; font-size:0.95rem; margin:0; text-align:center; word-break:break-word; }
 .calendar-menu-bar .mini-value { font-weight:700; text-align:center; font-size:1.5rem; }
-.calendar-menu-bar .mini-widget { gap:0.75rem; }
-.calendar-menu-bar .mini-split, .calendar-menu-bar .mini-triple { display:flex; gap:0.75rem; justify-content:center; }
+.calendar-menu-bar .mini-split, .calendar-menu-bar .mini-triple { display:flex; flex-wrap:wrap; gap:var(--space-sm); justify-content:center; width:100%; }
 .calendar-menu-bar .mini-stat {
   border-radius: var(--radius-md);
   padding:0.5rem 0.75rem;
@@ -1099,8 +1105,11 @@ input[name="telefone"] { width:18ch; }
   justify-content:center;
   gap:0.25rem;
   min-width:72px;
+  min-height:72px;
   box-shadow: inset 0 0 0 1px rgba(0,0,0,0.05);
   text-align:center;
+  box-sizing:border-box;
+  overflow:hidden;
 }
 .calendar-menu-bar .mini-widget.mini-blue .mini-stat { background:#c9def8; }
 .calendar-menu-bar .mini-widget.mini-yellow .mini-stat { background:#ffe2a6; }
@@ -1109,14 +1118,23 @@ input[name="telefone"] { width:18ch; }
 .calendar-menu-bar .mini-widget.mini-blue { background:#e3f2fd; }
 .calendar-menu-bar .mini-widget.mini-yellow { background:#fff8e1; }
 .calendar-menu-bar .mini-widget.mini-empty { border:1px dashed var(--color-border); box-shadow:none; }
-.calendar-menu-bar .mini-widget.mini-actions { align-items:stretch; justify-content:flex-start; gap:0.5rem; padding:0.75rem; }
+.calendar-menu-bar .mini-widget.mini-actions { align-items:stretch; justify-content:center; gap:var(--space-sm); padding:var(--space-sm); }
 .calendar-menu-bar .mini-widget.mini-actions button { width:100%; border:none; border-radius:var(--radius-md); font-weight:700; text-transform:uppercase; padding:0.65rem 0.75rem; cursor:pointer; transition:filter 0.2s ease; letter-spacing:0.04em; }
 .calendar-menu-bar .mini-widget.mini-actions button.btn-eventos { background:var(--accent-orange); color:#fff; }
 .calendar-menu-bar .mini-widget.mini-actions button.btn-folgas { background:#424242; color:#fff; }
 .calendar-menu-bar .mini-widget.mini-actions button:hover { filter:brightness(0.95); }
 @media (max-width:768px){
-  .calendar-menu-bar{ grid-template-columns:1fr; }
+  .calendar-menu-bar{ align-items:stretch; }
   .calendar-menu-bar .menu-actions{ justify-content:flex-start; }
+}
+@media (min-width: 992px){
+  .calendar-menu-bar{ flex-direction:row; }
+  .calendar-menu-bar .menu-actions{ align-self:center; }
+  .calendar-menu-bar .menu-widgets{ justify-content:flex-start; }
+}
+@media (max-width: 640px){
+  .calendar-menu-bar .mini-widget{ flex:1 1 100%; min-width:0; }
+  .calendar-menu-bar .mini-widget.mini-actions{ padding:var(--space-sm); }
 }
 
 .chips { display:flex; flex-wrap:wrap; gap:0.5rem; }


### PR DESCRIPTION
## Summary
- realign sidebar navigation items with a consistent grid layout so icons stay centered when collapsing the menu
- refactor dashboard stat cards to use a flexible layout with uniform padding, overflow handling, and responsive wrapping

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0436ba6883339a46be6b851de9ab