### PR TITLE
Fix dashboard cards layout and sidebar alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -147,8 +147,7 @@ a { color: inherit; text-decoration: none; }
 }
 .nav-item {
   min-height: 44px;
-  display: grid;
-  grid-template-columns: 24px 1fr auto;
+  display: flex;
   align-items: center;
   gap: 10px;
   padding: 0 16px 0 18px;
@@ -178,9 +177,10 @@ a { color: inherit; text-decoration: none; }
   display: inline-block;
   transition: transform 0.2s ease;
   transform-origin: left center;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   line-height: 1.2;
 }
+.nav-item .label { flex: 1 1 auto; }
 .sidebar:not(.is-expanded) .nav-item,
 .sidebar:not(.is-expanded) .nav-subitem {
   margin-inline: 12px;
@@ -189,7 +189,6 @@ a { color: inherit; text-decoration: none; }
 }
 .sidebar:not(.is-expanded) .nav-item {
   justify-content: center;
-  grid-template-columns: 24px;
   gap: 0;
 }
 .sidebar:not(.is-expanded) .nav-item .label,
@@ -199,6 +198,10 @@ a { color: inherit; text-decoration: none; }
   visibility: hidden;
   width: 0;
   transform: none;
+}
+.sidebar:not(.is-expanded) .nav-item .label,
+.sidebar:not(.is-expanded) .nav-item .submenu-caret {
+  flex: 0 0 auto;
 }
 .sidebar.is-expanded .nav-item,
 .sidebar.is-expanded .nav-subitem {
@@ -237,8 +240,10 @@ a { color: inherit; text-decoration: none; }
 }
 .nav-item.has-submenu { position: relative; }
 .nav-item.has-submenu .submenu-caret {
-  margin-left: 0;
-  justify-self: end;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
   font-size: 0.75rem;
   transform: rotate(0deg);
   transition: transform 0.2s ease;
@@ -1090,12 +1095,14 @@ input[name="telefone"] { width:18ch; }
 
 /* ===== Calendar Menu Bar ===== */
 .calendar-menu-bar { background:var(--surface); border-radius:var(--radius-lg); padding:var(--space-md); display:flex; flex-direction:column; gap:var(--space-md); align-items:stretch; margin-bottom:1.5rem; width:100%; box-sizing:border-box; }
-.calendar-menu-bar .menu-actions { display:flex; flex-wrap:wrap; gap:var(--space-sm); align-items:center; align-self:flex-start; }
-.calendar-menu-bar .menu-widgets { display:flex; flex-wrap:wrap; gap:var(--space-md); align-items:stretch; justify-content:flex-start; width:100%; }
-.calendar-menu-bar .mini-widget { background:var(--surface); border:1px solid var(--color-border); border-radius:var(--radius-md); padding:var(--space-md); display:flex; flex-direction:column; align-items:center; justify-content:center; min-width:180px; flex:1 1 200px; min-height:140px; box-shadow:var(--card-shadow); box-sizing:border-box; overflow:hidden; text-align:center; gap:var(--space-sm); }
+.calendar-menu-bar .menu-actions { display:flex; flex-wrap:wrap; gap:var(--space-sm); align-items:center; align-self:flex-start; flex:0 0 auto; }
+.calendar-menu-bar .menu-widgets { display:grid; grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); grid-auto-rows:minmax(160px, auto); gap:var(--space-md); align-items:stretch; width:100%; box-sizing:border-box; flex:1 1 auto; }
+.calendar-menu-bar .mini-widget { background:var(--surface); border:1px solid var(--color-border); border-radius:var(--radius-md); padding:var(--space-md); display:flex; flex-direction:column; align-items:center; justify-content:center; min-height:160px; box-shadow:var(--card-shadow); box-sizing:border-box; overflow:hidden; text-align:center; gap:var(--space-sm); width:100%; }
 .calendar-menu-bar .mini-title { font-weight:700; font-size:0.95rem; margin:0; text-align:center; word-break:break-word; }
 .calendar-menu-bar .mini-value { font-weight:700; text-align:center; font-size:1.5rem; }
-.calendar-menu-bar .mini-split, .calendar-menu-bar .mini-triple { display:flex; flex-wrap:wrap; gap:var(--space-sm); justify-content:center; width:100%; }
+.calendar-menu-bar .mini-split, .calendar-menu-bar .mini-triple { display:grid; gap:var(--space-sm); justify-items:center; align-items:center; width:100%; box-sizing:border-box; }
+.calendar-menu-bar .mini-split { grid-template-columns:repeat(auto-fit, minmax(120px, 1fr)); }
+.calendar-menu-bar .mini-triple { grid-template-columns:repeat(auto-fit, minmax(100px, 1fr)); }
 .calendar-menu-bar .mini-stat {
   border-radius: var(--radius-md);
   padding:0.5rem 0.75rem;
@@ -1104,8 +1111,9 @@ input[name="telefone"] { width:18ch; }
   align-items:center;
   justify-content:center;
   gap:0.25rem;
-  min-width:72px;
+  min-width:0;
   min-height:72px;
+  width:100%;
   box-shadow: inset 0 0 0 1px rgba(0,0,0,0.05);
   text-align:center;
   box-sizing:border-box;
@@ -1118,8 +1126,8 @@ input[name="telefone"] { width:18ch; }
 .calendar-menu-bar .mini-widget.mini-blue { background:#e3f2fd; }
 .calendar-menu-bar .mini-widget.mini-yellow { background:#fff8e1; }
 .calendar-menu-bar .mini-widget.mini-empty { border:1px dashed var(--color-border); box-shadow:none; }
-.calendar-menu-bar .mini-widget.mini-actions { align-items:stretch; justify-content:center; gap:var(--space-sm); padding:var(--space-sm); }
-.calendar-menu-bar .mini-widget.mini-actions button { width:100%; border:none; border-radius:var(--radius-md); font-weight:700; text-transform:uppercase; padding:0.65rem 0.75rem; cursor:pointer; transition:filter 0.2s ease; letter-spacing:0.04em; }
+.calendar-menu-bar .mini-widget.mini-actions { align-items:center; justify-content:center; gap:var(--space-sm); padding:var(--space-sm); }
+.calendar-menu-bar .mini-widget.mini-actions button { width:100%; border:none; border-radius:var(--radius-md); font-weight:700; text-transform:uppercase; padding:0.65rem 0.75rem; cursor:pointer; transition:filter 0.2s ease; letter-spacing:0.04em; box-sizing:border-box; }
 .calendar-menu-bar .mini-widget.mini-actions button.btn-eventos { background:var(--accent-orange); color:#fff; }
 .calendar-menu-bar .mini-widget.mini-actions button.btn-folgas { background:#424242; color:#fff; }
 .calendar-menu-bar .mini-widget.mini-actions button:hover { filter:brightness(0.95); }
@@ -1133,7 +1141,7 @@ input[name="telefone"] { width:18ch; }
   .calendar-menu-bar .menu-widgets{ justify-content:flex-start; }
 }
 @media (max-width: 640px){
-  .calendar-menu-bar .mini-widget{ flex:1 1 100%; min-width:0; }
+  .calendar-menu-bar .mini-widget{ min-width:0; }
   .calendar-menu-bar .mini-widget.mini-actions{ padding:var(--space-sm); }
 }
 


### PR DESCRIPTION
## Summary
- switch the dashboard mini widgets to a CSS grid with consistent sizing and overflow protection
- center content inside the top dashboard cards and keep the Eventos/Folgas actions aligned with the other widgets
- refactor sidebar navigation items to use flexbox so icons stay vertically aligned when the menu expands or collapses and reduce label typography to fit

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb066599cc8333bbb5b12e3055b61a