### PR TITLE
Adjust calendar dashboard layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -952,7 +952,6 @@ function renderCalendarMenuBar(){
   return `
     <div class="calendar-menu-bar">
       <div class="menu-actions">
-        <button class="btn btn-cal-eventos">Eventos</button>
         <button class="btn btn-cal-desfalques" style="display:none">Desfalques</button>
       </div>
       <div class="menu-widgets">
@@ -1009,6 +1008,8 @@ function renderCalendarMenuBar(){
             <div class="mini-value" data-stat="os-hoje">0</div>
             <div class="mini-label">Hoje</div>
           </div>
+        </div>
+        <div class="mini-widget mini-actions-only">
           <div class="mini-actions-inline">
             <button class="btn-eventos" type="button">Eventos</button>
             <button class="btn-folgas" type="button">Folgas</button>
@@ -1070,30 +1071,34 @@ function renderCalendario() {
       <div class="card" data-card-id="calendario" data-colspan="12">
         <div class="card-body calendario-wrapper">
           <div id="calendar" class="calendar">
-          <div class="cal-toolbar">
-          <div class="cal-nav">
-            <button class="btn cal-prev" aria-label="Mês anterior">&#8249;</button>
-            <h2 class="cal-mes monthTitle"></h2>
-            <button class="btn cal-next" aria-label="Próximo mês">&#8250;</button>
-          </div>
-          <div class="cal-right">
-            <select class="cal-mes-select" aria-label="Mês"></select>
-            <select class="cal-ano" aria-label="Ano"></select>
-            <button class="btn cal-hoje">Hoje</button>
-            <div class="segmented" role="group" aria-label="Modo de visualização">
-              <button class="seg-btn" data-modo="mes" aria-pressed="true">Mês</button>
-              <button class="seg-btn" data-modo="semana" aria-pressed="false">Semana</button>
+            <div class="cal-toolbar">
+              <div class="cal-nav">
+                <button class="btn cal-prev" aria-label="Mês anterior">&#8249;</button>
+                <h2 class="cal-mes monthTitle"></h2>
+                <button class="btn cal-next" aria-label="Próximo mês">&#8250;</button>
+              </div>
+              <div class="cal-right">
+                <button class="btn btn-cal-eventos">Adicionar Evento</button>
+                <div class="cal-controls">
+                  <select class="cal-mes-select" aria-label="Mês"></select>
+                  <select class="cal-ano" aria-label="Ano"></select>
+                  <button class="btn cal-hoje">Hoje</button>
+                  <div class="segmented" role="group" aria-label="Modo de visualização">
+                    <button class="seg-btn" data-modo="mes" aria-pressed="true">Mês</button>
+                    <button class="seg-btn" data-modo="semana" aria-pressed="false">Semana</button>
+                  </div>
+                </div>
+              </div>
             </div>
+            <div class="cal-weekdays"></div>
+            <div class="cal-week-nav">
+              <button class="btn cal-prev-week">&#8249; Semana</button>
+              <button class="btn cal-next-week">Semana &#8250;</button>
+            </div>
+            <div class="cal-grid"></div>
+            <div id="calPopoverLayer" class="cal-popover-layer"></div>
+            <div class="cal-empty empty-state" style="display:none">Nada por aqui ainda</div>
           </div>
-        </div>
-        <div class="cal-weekdays"></div>
-        <div class="cal-week-nav">
-          <button class="btn cal-prev-week">&#8249; Semana</button>
-          <button class="btn cal-next-week">Semana &#8250;</button>
-        </div>
-        <div class="cal-grid"></div>
-        <div id="calPopoverLayer" class="cal-popover-layer"></div>
-        <div class="cal-empty empty-state" style="display:none">Nada por aqui ainda</div>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -1060,7 +1060,8 @@ input[name="telefone"] { width:18ch; }
 /* ===== Calendar ===== */
 .calendario-wrapper { display:flex; flex-direction:column; gap:1rem; width:100%; --neutral-100: var(--color-border); --green-600: var(--color-primary); --red-600: #c62828; --red-400: #e57373; --card-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .cal-toolbar { display:flex; flex-wrap:wrap; align-items:center; justify-content:space-between; gap:1rem; }
-.cal-right { display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; }
+.cal-right { display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap; width:100%; }
+.cal-controls { display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; margin-left:auto; }
 .cal-nav {
   display:flex;
   align-items:center;
@@ -1128,32 +1129,35 @@ input[name="telefone"] { width:18ch; }
 .segmented [aria-pressed="false"] { background:var(--neutral-200); color:var(--color-text); }
 
 /* ===== Calendar Menu Bar ===== */
-.calendar-menu-bar { background:var(--surface); border-radius:var(--radius-lg); padding:clamp(16px,2.6vw,24px); display:flex; flex-direction:column; gap:clamp(12px,1.8vw,20px); align-items:stretch; margin:0 auto 1.5rem; width:min(100%,1200px); box-sizing:border-box; }
+.calendar-menu-bar { background:var(--surface); border-radius:var(--radius-lg); padding:clamp(12px,1.6vw,16px); display:flex; flex-direction:column; gap:clamp(10px,1.4vw,16px); align-items:stretch; margin:0 auto 1.5rem; width:100%; max-width:1200px; box-sizing:border-box; }
 .calendar-menu-bar .menu-actions { display:flex; flex-wrap:wrap; gap:var(--space-sm); align-items:center; align-self:flex-start; flex:0 0 auto; }
-.calendar-menu-bar .menu-widgets { display:grid; grid-template-columns:repeat(4,1fr); grid-auto-flow:column; grid-auto-columns:minmax(clamp(200px,22vw,260px),1fr); gap:clamp(12px,1.8vw,20px); align-items:stretch; width:100%; box-sizing:border-box; flex:1 1 auto; overflow-x:auto; padding-bottom:4px; scroll-behavior:smooth; overscroll-behavior-inline:contain; }
+.calendar-menu-bar .menu-widgets { display:grid; grid-template-columns:repeat(4,1fr); grid-auto-flow:column; grid-auto-columns:minmax(clamp(200px,22vw,260px),1fr); gap:clamp(10px,1.4vw,16px); align-items:stretch; width:100%; box-sizing:border-box; flex:1 1 auto; overflow-x:auto; padding-bottom:4px; scroll-behavior:smooth; overscroll-behavior-inline:contain; }
 .calendar-menu-bar .menu-widgets::-webkit-scrollbar{height:6px;}
 .calendar-menu-bar .menu-widgets::-webkit-scrollbar-thumb{background:rgba(0,0,0,0.15);border-radius:999px;}
-.calendar-menu-bar .mini-widget { background:var(--surface); border:1px solid var(--color-border); border-radius:var(--radius-md); padding:clamp(12px,1.6vw,18px); display:flex; flex-direction:column; align-items:center; justify-content:center; min-height:clamp(128px,18vw,160px); box-shadow:var(--card-shadow); box-sizing:border-box; overflow:hidden; text-align:center; gap:clamp(8px,1.4vw,12px); width:100%; }
+.calendar-menu-bar .mini-widget { background:var(--surface); border:1px solid var(--color-border); border-radius:var(--radius-md); padding:clamp(10px,1.2vw,14px); display:flex; flex-direction:column; align-items:center; justify-content:center; min-height:clamp(64px,9vw,80px); box-shadow:var(--card-shadow); box-sizing:border-box; overflow:hidden; text-align:center; gap:clamp(6px,1vw,10px); width:100%; }
 .calendar-menu-bar .mini-title { font-weight:700; font-size:clamp(0.78rem,1.4vw,0.95rem); margin:0; text-align:center; word-break:break-word; }
 .calendar-menu-bar .mini-value { font-weight:700; text-align:center; font-size:clamp(1.05rem,2.8vw,1.6rem); }
+.calendar-menu-bar .mini-value,
+.calendar-menu-bar .mini-label { flex:0 0 auto; }
 .calendar-menu-bar .mini-split, .calendar-menu-bar .mini-triple { display:grid; gap:clamp(8px,1.2vw,12px); justify-items:center; align-items:center; width:100%; box-sizing:border-box; }
 .calendar-menu-bar .mini-split { grid-template-columns:repeat(auto-fit, minmax(120px, 1fr)); }
 .calendar-menu-bar .mini-triple { grid-template-columns:repeat(auto-fit, minmax(110px, 1fr)); }
 .calendar-menu-bar .mini-stat {
   border-radius: var(--radius-md);
-  padding:clamp(10px,1.4vw,14px) clamp(12px,1.8vw,16px);
+  padding:clamp(8px,1vw,12px) clamp(12px,1.6vw,16px);
   display:flex;
-  flex-direction:column;
+  flex-direction:row;
   align-items:center;
   justify-content:center;
-  gap:clamp(4px,0.8vw,8px);
+  gap:clamp(6px,1vw,12px);
   min-width:0;
-  min-height:72px;
+  min-height:48px;
   width:100%;
   box-shadow: inset 0 0 0 1px rgba(0,0,0,0.05);
   text-align:center;
   box-sizing:border-box;
   overflow:hidden;
+  white-space:nowrap;
 }
 .calendar-menu-bar .mini-stat.mini-single{ max-width:220px; }
 .calendar-menu-bar .mini-widget.mini-blue .mini-stat { background:#c9def8; }
@@ -1164,6 +1168,9 @@ input[name="telefone"] { width:18ch; }
 .calendar-menu-bar .mini-widget.mini-blue { background:#e3f2fd; }
 .calendar-menu-bar .mini-widget.mini-yellow { background:#fff8e1; }
 .calendar-menu-bar .mini-widget.mini-compact { background:#fff8e1; align-items:center; }
+.calendar-menu-bar .mini-widget.mini-actions-only { background:var(--surface); justify-content:center; min-height:clamp(64px,9vw,80px); }
+.calendar-menu-bar .mini-widget.mini-actions-only .mini-actions-inline { justify-content:center; gap:clamp(8px,1vw,12px); flex-wrap:nowrap; white-space:nowrap; overflow-x:auto; }
+.calendar-menu-bar .mini-widget.mini-actions-only .mini-actions-inline button { flex:0 0 auto; }
 .calendar-menu-bar .mini-actions-inline { display:flex; align-items:center; justify-content:center; gap:var(--space-sm); width:100%; box-sizing:border-box; flex-wrap:nowrap; }
 .calendar-menu-bar .mini-actions-inline button { flex:1 1 auto; min-width:0; border:none; border-radius:var(--radius-md); font-weight:700; text-transform:uppercase; padding:clamp(10px,1.8vw,12px) clamp(12px,2vw,16px); cursor:pointer; transition:filter 0.2s ease; letter-spacing:0.04em; box-sizing:border-box; font-size:clamp(0.7rem,1.2vw,0.85rem); }
 .calendar-menu-bar .mini-actions-inline button.btn-eventos { background:var(--accent-orange); color:#fff; }


### PR DESCRIPTION
## Summary
- resize the dashboard mini-widgets and align their layout with the calendar width
- move the Eventos/Folgas actions into a dedicated widget and keep the calendar toolbar controls on a single row
- reposition the orange Eventos button near the calendar controls as “Adicionar Evento” while preserving existing behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb16240b288333ab0c981239faa95e