### PR TITLE
Refine calendário layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -1072,21 +1072,23 @@ function renderCalendario() {
         <div class="card-body calendario-wrapper">
           <div id="calendar" class="calendar">
             <div class="cal-toolbar">
+              <div class="cal-actions">
+                <button class="btn btn-cal-eventos">Adicionar Evento</button>
+              </div>
               <div class="cal-nav">
                 <button class="btn cal-prev" aria-label="Mês anterior">&#8249;</button>
                 <h2 class="cal-mes monthTitle"></h2>
                 <button class="btn cal-next" aria-label="Próximo mês">&#8250;</button>
               </div>
-              <div class="cal-right">
-                <button class="btn btn-cal-eventos">Adicionar Evento</button>
-                <div class="cal-controls">
+              <div class="cal-controls">
+                <div class="cal-selects">
                   <select class="cal-mes-select" aria-label="Mês"></select>
                   <select class="cal-ano" aria-label="Ano"></select>
-                  <button class="btn cal-hoje">Hoje</button>
-                  <div class="segmented" role="group" aria-label="Modo de visualização">
-                    <button class="seg-btn" data-modo="mes" aria-pressed="true">Mês</button>
-                    <button class="seg-btn" data-modo="semana" aria-pressed="false">Semana</button>
-                  </div>
+                </div>
+                <button class="btn cal-hoje">Hoje</button>
+                <div class="segmented" role="group" aria-label="Modo de visualização">
+                  <button class="seg-btn" data-modo="mes" aria-pressed="true">Mês</button>
+                  <button class="seg-btn" data-modo="semana" aria-pressed="false">Semana</button>
                 </div>
               </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -1058,19 +1058,90 @@ input[name="telefone"] { width:18ch; }
   }
 }
 /* ===== Calendar ===== */
-.calendario-wrapper { display:flex; flex-direction:column; gap:1rem; width:100%; --neutral-100: var(--color-border); --green-600: var(--color-primary); --red-600: #c62828; --red-400: #e57373; --card-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-.cal-toolbar { display:flex; flex-wrap:wrap; align-items:center; justify-content:space-between; gap:1rem; }
-.cal-right { display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap; width:100%; }
-.cal-controls { display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; margin-left:auto; }
-.cal-nav {
+.calendario-wrapper { display:flex; flex-direction:column; gap:1.5rem; width:100%; --neutral-100: var(--color-border); --green-600: var(--color-primary); --red-600: #c62828; --red-400: #e57373; --card-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+.cal-toolbar {
+  display:grid;
+  grid-template-columns:auto 1fr auto;
+  align-items:center;
+  gap:1.5rem;
+  padding:16px 20px;
+  background:#f4f6fa;
+  border-radius:20px;
+  box-shadow:inset 0 0 0 1px rgba(15,23,42,0.04);
+}
+.cal-actions {
   display:flex;
   align-items:center;
-  justify-content:center;
-  position:relative;
-  padding:0 3.5rem;
-  width:clamp(240px, 30vw, 320px);
-  max-width:100%;
+  gap:0.75rem;
+  justify-content:flex-start;
 }
+.cal-controls {
+  display:flex;
+  align-items:center;
+  gap:0.75rem;
+  justify-self:end;
+  justify-content:flex-end;
+  padding:6px 12px;
+  border-radius:999px;
+  background:#fff;
+  box-shadow:0 10px 24px rgba(15,23,42,0.06);
+  border:1px solid rgba(15,23,42,0.05);
+  flex-wrap:wrap;
+}
+.cal-controls .cal-selects { display:flex; align-items:center; gap:0.5rem; }
+.cal-controls select {
+  background:#f1f5f9;
+  border:1px solid rgba(15,23,42,0.08);
+  border-radius:999px;
+  font-weight:600;
+  color:#1f2937;
+  padding:0.35rem 1rem;
+  min-width:120px;
+  appearance:none;
+  -webkit-appearance:none;
+  -moz-appearance:none;
+  background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2363748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat:no-repeat;
+  background-position:right 0.85rem center;
+  background-size:12px;
+  padding-right:2.25rem;
+}
+.cal-controls select:focus {
+  outline:none;
+  box-shadow:0 0 0 3px rgba(59,130,246,0.18);
+}
+.cal-controls .cal-hoje {
+  background:#e2e8f0;
+  color:#1f2937;
+  font-weight:600;
+  border-radius:999px;
+  padding:0.35rem 1rem;
+}
+.cal-controls .cal-hoje:hover { filter:brightness(0.95); }
+.cal-controls .segmented {
+  background:#d1fae5;
+  padding:4px;
+  border-radius:999px;
+  gap:4px;
+}
+.cal-controls .segmented button {
+  padding:0.35rem 1.05rem;
+  border-radius:999px;
+  font-weight:700;
+  border:none;
+}
+.cal-controls .segmented [aria-pressed="true"] {
+  background:#fff;
+  color:#065f46;
+  box-shadow:0 10px 20px rgba(16,185,129,0.15);
+}
+.cal-controls .segmented [aria-pressed="false"] {
+  background:#16a34a;
+  color:#fff;
+}
+.cal-nav { display:flex; align-items:center; justify-content:center; gap:1rem; width:100%; }
+.cal-nav .cal-prev,
+.cal-nav .cal-next { position:static; transform:none; }
 
 .client-detail-modal{display:grid;gap:16px;padding:4px;}
 .client-detail-modal .mini-card{background:var(--surface);border-radius:var(--radius-lg);box-shadow:var(--card-shadow);padding:16px;display:flex;flex-direction:column;gap:12px;}
@@ -1090,40 +1161,62 @@ input[name="telefone"] { width:18ch; }
 .followup-badge.is-pending{background:#fce8d8;color:#b15b00;}
 .modal-dialog.modal-cliente-detalhe{max-width:840px;}
 .cal-nav button {
-  width:48px;
-  height:48px;
-  border-radius:var(--radius-md);
+  width:44px;
+  height:44px;
+  border-radius:14px;
   display:grid;
   place-items:center;
   padding:0;
+  background:#fff;
+  border:1px solid rgba(15,23,42,0.1);
+  color:#1f2937;
+  font-size:1.5rem;
+  box-shadow:0 8px 20px rgba(15,23,42,0.08);
 }
-.cal-nav .cal-prev,
-.cal-nav .cal-next {
-  position:absolute;
-  top:50%;
-  transform:translateY(-50%);
-}
-.cal-nav .cal-prev { left:0; }
-.cal-nav .cal-next { right:0; }
+.cal-nav button:hover { filter:brightness(0.95); }
 .cal-nav .cal-mes {
   text-align:center;
-  font-size:1.5rem;
+  font-size:1.45rem;
   margin:0;
   flex:0 0 auto;
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
-  padding:0 0.25rem;
+  padding:0 0.5rem;
+  letter-spacing:0.24em;
+  text-transform:uppercase;
+  font-weight:800;
+  color:#1f2937;
 }
-.cal-toolbar button, .cal-toolbar select, .cal-toolbar input { font:inherit; height:36px; }
-.cal-toolbar .btn { padding:0 0.75rem; }
-.btn-cal-eventos { background:var(--accent-orange); color:#fff; }
+.cal-toolbar button, .cal-toolbar select, .cal-toolbar input { font:inherit; height:auto; }
+.cal-toolbar .btn { padding:0.5rem 1.25rem; }
+.btn-cal-eventos {
+  background:#ff8a2a;
+  color:#fff;
+  font-weight:700;
+  border-radius:999px;
+  padding:0.55rem 1.5rem;
+  box-shadow:0 12px 26px rgba(249,138,42,0.35);
+  border:none;
+}
 .btn-cal-eventos:hover { filter:brightness(0.95); }
 .btn-cal-desfalques { background:#555; color:#fff; }
 .btn-cal-desfalques:hover { filter:brightness(0.95); }
-.monthTitle { text-transform:uppercase; font-weight:700; letter-spacing:.04em; white-space:nowrap; max-width:320px; overflow:hidden; text-overflow:ellipsis; margin:0; text-align:center; font-size:1.5rem; }
-.segmented { display:inline-flex; background:var(--neutral-100); border-radius:var(--radius-lg); padding:2px; gap:2px; }
-.segmented button { padding:6px 12px; border-radius:var(--radius-lg); font:inherit; border:none; }
+.monthTitle {
+  text-transform:uppercase;
+  font-weight:800;
+  letter-spacing:0.24em;
+  white-space:nowrap;
+  max-width:360px;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  margin:0;
+  text-align:center;
+  font-size:1.45rem;
+  color:#1f2937;
+}
+.segmented { display:inline-flex; background:var(--neutral-100); border-radius:999px; padding:4px; gap:4px; }
+.segmented button { padding:0.35rem 1rem; border-radius:999px; font:inherit; border:none; font-weight:600; }
 .segmented button:focus { outline:none; box-shadow:0 0 0 2px var(--color-primary); }
 .segmented [aria-pressed="true"] { background:var(--color-primary); color:#fff; }
 .segmented [aria-pressed="false"] { background:var(--neutral-200); color:var(--color-text); }
@@ -1195,22 +1288,110 @@ input[name="telefone"] { width:18ch; }
 .chip[aria-pressed="true"] { background:var(--color-primary); color:#fff; }
 .chip:focus { outline:none; box-shadow:0 0 0 2px var(--color-primary); }
 .clients-toolbar .search-input { height:100%; }
-.cal-weekdays { display:grid; grid-template-columns:repeat(7,1fr); background: var(--color-accent); border-radius: var(--radius-lg); }
-.cal-weekdays div { padding:0.5rem; text-align:center; font-weight:bold; }
+.cal-weekdays {
+  display:grid;
+  grid-template-columns:repeat(7, minmax(0,1fr));
+  background:#eff2f7;
+  border-radius:16px;
+  border:1px solid rgba(15,23,42,0.05);
+  padding:0.75rem 0;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+}
+.cal-weekdays div {
+  padding:0.25rem 0;
+  text-align:center;
+  font-weight:700;
+  font-size:0.75rem;
+  color:#475569;
+}
 .cal-week-nav { display:none; justify-content:space-between; align-items:center; }
 .cal-week-nav button { padding:0.25rem 0.5rem; }
-.cal-grid { display:grid; grid-template-columns:repeat(7,1fr); grid-auto-rows:minmax(var(--cell-min-h,72px),auto); gap:0.75rem; }
-.calendar-day { background: var(--color-bg); border:1px solid var(--color-border); border-radius: var(--radius-lg); box-shadow:0 2px 4px rgba(0,0,0,0.05); padding:0.25rem; padding-top:calc(0.25rem + 14px); display:flex; flex-direction:column; align-content:flex-start; position:relative; min-width:0; }
-.calendar-day.today { border-color: var(--color-primary); }
-.calendar-day.day--outside { background: var(--color-app-bg); color: var(--text-muted); }
-.calendar-day.day--outside .day-num { color: var(--text-muted); }
-.day-head{position:relative; height:22px}
-.day-num{position:absolute; right:6px; top:0; font-weight:700}
-.today-badge{position:absolute; left:50%; top:0; transform:translateX(-50%); font-weight:800; color:#2e7dd7}
-.calendar-item { display:flex; align-items:center; gap:0.25rem; margin-top:0.5rem; min-width:0; }
+.cal-grid {
+  display:grid;
+  grid-template-columns:repeat(7, minmax(0,1fr));
+  grid-auto-rows:minmax(150px,auto);
+  gap:1rem;
+}
+.calendar-day {
+  background:#fff;
+  border:1px solid rgba(15,23,42,0.06);
+  border-radius:18px;
+  box-shadow:0 16px 32px rgba(15,23,42,0.08);
+  padding:1rem;
+  display:flex;
+  flex-direction:column;
+  align-content:flex-start;
+  gap:0.5rem;
+  position:relative;
+  min-width:0;
+  transition:transform 0.2s ease, box-shadow 0.2s ease;
+  overflow:hidden;
+}
+.calendar-day:hover { transform:translateY(-2px); box-shadow:0 22px 42px rgba(15,23,42,0.12); }
+.calendar-day.today {
+  border-color:#16a34a;
+  box-shadow:0 0 0 2px rgba(22,163,74,0.2), 0 22px 42px rgba(15,23,42,0.12);
+}
+.calendar-day.day--outside {
+  background:#f8fafc;
+  color:#94a3b8;
+  border-style:dashed;
+  box-shadow:none;
+}
+.calendar-day.day--outside .day-num { color:#94a3b8; }
+.day-head {
+  position:relative;
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:0.5rem;
+  height:auto;
+}
+.day-num {
+  position:static;
+  font-weight:700;
+  font-size:1.2rem;
+  color:#1f2937;
+}
+.today-badge {
+  position:static;
+  transform:none;
+  background:#16a34a;
+  color:#fff;
+  font-weight:700;
+  letter-spacing:0.1em;
+  font-size:0.65rem;
+  padding:0.15rem 0.6rem;
+  border-radius:999px;
+  text-transform:uppercase;
+}
+.calendar-item {
+  display:flex;
+  align-items:center;
+  gap:0.5rem;
+  margin-top:0.25rem;
+  min-width:0;
+}
 .day-add { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); width:32px; height:32px; border-radius:50%; background:var(--neutral-200); border:none; display:flex; align-items:center; justify-content:center; cursor:pointer; }
 .day-add:focus { outline:none; box-shadow:0 0 0 2px var(--green-500); }
-.calendar-chip { flex:1; padding:0.25rem 0.5rem; border-radius:var(--radius-md); background:var(--color-border); font-size:0.75rem; cursor:pointer; max-width:100%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; position:relative; display:flex; align-items:center; }
+.calendar-chip {
+  flex:1;
+  padding:0.45rem 0.75rem;
+  border-radius:12px;
+  background:#eef2ff;
+  font-size:0.8rem;
+  font-weight:600;
+  cursor:pointer;
+  max-width:100%;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  position:relative;
+  display:flex;
+  align-items:center;
+  color:#1f2937;
+}
 .calendar-chip.compra { background:var(--color-primary); color:#fff; }
 .calendar-chip.evento { background:var(--accent-orange); color:#fff; padding-right:20px; }
 .calendar-chip.evento.admin { background:#9c27b0; color:#fff; }
@@ -1218,8 +1399,20 @@ input[name="telefone"] { width:18ch; }
 .calendar-chip.evento[data-efetuado="false"]::after { content:""; position:absolute; right:0; top:0; width:14px; height:100%; background:var(--red-600); }
 .calendar-chip.evento[data-efetuado="true"]::after { display:none; }
 .calendar-chip.desfalque { background:#555; color:#fff; }
-.cal-ano, .cal-mes-select { min-height:36px; padding:0 0.75rem; border-radius:var(--radius-lg); }
-.calendar-card { padding:0.5rem; border-radius:var(--radius-md); background:var(--color-border); margin-top:0.5rem; cursor:pointer; position:relative; max-width:100%; overflow:hidden; white-space:normal; }
+.cal-ano, .cal-mes-select { min-height:auto; padding:0; border-radius:0; }
+.calendar-card {
+  padding:0.75rem 1rem;
+  border-radius:16px;
+  background:#fff;
+  border:1px solid rgba(15,23,42,0.05);
+  margin-top:0.5rem;
+  cursor:pointer;
+  position:relative;
+  max-width:100%;
+  overflow:hidden;
+  white-space:normal;
+  box-shadow:0 10px 24px rgba(15,23,42,0.08);
+}
 .calendar-card.compra { background:var(--color-primary); color:#fff; }
 .calendar-card.evento { background:var(--accent-orange); color:#fff; padding-left:0; padding-right:1.25rem; }
 .calendar-card.evento.admin { background:#9c27b0; color:#fff; }
@@ -1262,9 +1455,43 @@ input[name="telefone"] { width:18ch; }
 .switch:checked { background:var(--color-primary); }
 .switch:checked:before { transform:translateX(20px); }
 @media (max-width:768px){
-  .cal-toolbar { grid-template-columns:1fr; row-gap:8px; }
-  .cal-right { justify-self:end; }
-  .cal-nav { justify-self:center; }
+  .cal-toolbar {
+    grid-template-columns:1fr;
+    row-gap:12px;
+    justify-items:stretch;
+  }
+  .cal-actions {
+    width:100%;
+  }
+  .cal-actions .btn-cal-eventos {
+    width:100%;
+    text-align:center;
+  }
+  .cal-nav {
+    order:-1;
+  }
+  .cal-controls {
+    justify-self:stretch;
+    flex-wrap:wrap;
+    justify-content:flex-start;
+    gap:0.5rem;
+  }
+  .cal-controls .cal-selects {
+    width:100%;
+    justify-content:space-between;
+  }
+  .cal-controls .segmented {
+    width:100%;
+    justify-content:space-between;
+  }
+}
+
+@media (max-width:1024px){
+  .cal-grid { grid-auto-rows:minmax(130px,auto); gap:0.85rem; }
+}
+
+@media (max-width:640px){
+  .cal-grid { grid-auto-rows:minmax(110px,auto); gap:0.75rem; }
 }
 .table-usuarios td.acoes { display:flex; gap:4px; }
 .opcoes h4 { margin:0 0 0.5rem 0; font-size:0.875rem; color:var(--text-weak); }
@@ -1366,15 +1593,20 @@ input[name="telefone"] { width:18ch; }
 .dash-add-menu button:hover{background:#f5f7fa}
 
 .calendar {
-  background: #f8fbff;
-  border-radius: 14px;
-  padding: 10px 12px 16px;
-  width: 100%;
-  box-sizing: border-box;
+  background:#fff;
+  border-radius:24px;
+  padding:24px;
+  width:100%;
+  box-sizing:border-box;
+  border:1px solid rgba(15,23,42,0.05);
+  box-shadow:0 24px 48px rgba(15,23,42,0.08);
+  display:flex;
+  flex-direction:column;
+  gap:1.5rem;
 }
-.cal-toolbar, .calendar-toolbar { margin-bottom: 10px; }
-.cal-weekdays, .calendar-weeknames { margin: 6px 0 8px; }
-.cal-grid, .calendar-grid { margin-top: 6px; }
+.cal-toolbar, .calendar-toolbar { margin-bottom: 0; }
+.cal-weekdays, .calendar-weeknames { margin: 0; }
+.cal-grid, .calendar-grid { margin-top: 0; }
 .event.followup, .event-color-followup, .calendar-chip.followup, .calendar-card.followup { background:#bfe0ff; color:#0c2a4a; }
 .event-color-os, .calendar-chip.event-color-os, .calendar-card.event-color-os { background:#ffeb3b; color:#000; }
 


### PR DESCRIPTION
## Summary
- reorganize the calendário toolbar so the evento button, month navigation, and view controls can follow the new layout
- refresh the calendar container and control styling with rounded pills, updated colors, and responsive tweaks to match the reference
- restyle weekday headers, day cells, and event chips/cards with new spacing, shadows, and typography for a cleaner grid

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb19277a3883338083de5ff7b9ce3b