### PR TITLE
Adjust calendar toolbar layout and styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -1060,43 +1060,44 @@ input[name="telefone"] { width:18ch; }
 /* ===== Calendar ===== */
 .calendario-wrapper { display:flex; flex-direction:column; gap:1.5rem; width:100%; --neutral-100: var(--color-border); --green-600: var(--color-primary); --red-600: #c62828; --red-400: #e57373; --card-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .cal-toolbar {
-  display:grid;
-  grid-template-columns:auto 1fr auto;
+  display:flex;
   align-items:center;
-  gap:1.5rem;
+  gap:1rem;
   padding:16px 20px;
   background:#f4f6fa;
   border-radius:20px;
   box-shadow:inset 0 0 0 1px rgba(15,23,42,0.04);
+  flex-wrap:nowrap;
 }
 .cal-actions {
   display:flex;
   align-items:center;
   gap:0.75rem;
   justify-content:flex-start;
+  flex:0 0 auto;
 }
 .cal-controls {
   display:flex;
   align-items:center;
-  gap:0.75rem;
-  justify-self:end;
+  gap:0.6rem;
   justify-content:flex-end;
-  padding:6px 12px;
-  border-radius:999px;
-  background:#fff;
-  box-shadow:0 10px 24px rgba(15,23,42,0.06);
-  border:1px solid rgba(15,23,42,0.05);
-  flex-wrap:wrap;
+  flex:0 0 auto;
+  padding:0;
+  border-radius:12px;
+  background:transparent;
+  box-shadow:none;
+  border:none;
+  white-space:nowrap;
 }
 .cal-controls .cal-selects { display:flex; align-items:center; gap:0.5rem; }
 .cal-controls select {
   background:#f1f5f9;
   border:1px solid rgba(15,23,42,0.08);
-  border-radius:999px;
+  border-radius:12px;
   font-weight:600;
   color:#1f2937;
   padding:0.35rem 1rem;
-  min-width:120px;
+  min-width:100px;
   appearance:none;
   -webkit-appearance:none;
   -moz-appearance:none;
@@ -1114,32 +1115,36 @@ input[name="telefone"] { width:18ch; }
   background:#e2e8f0;
   color:#1f2937;
   font-weight:600;
-  border-radius:999px;
+  border-radius:12px;
   padding:0.35rem 1rem;
 }
 .cal-controls .cal-hoje:hover { filter:brightness(0.95); }
 .cal-controls .segmented {
-  background:#d1fae5;
-  padding:4px;
-  border-radius:999px;
-  gap:4px;
+  display:flex;
+  align-items:center;
+  background:transparent;
+  padding:0;
+  border-radius:12px;
+  gap:0.35rem;
 }
 .cal-controls .segmented button {
   padding:0.35rem 1.05rem;
-  border-radius:999px;
+  border-radius:12px;
   font-weight:700;
-  border:none;
+  border:1px solid #16a34a;
+  background:#fff;
+  color:#16a34a;
 }
 .cal-controls .segmented [aria-pressed="true"] {
-  background:#fff;
-  color:#065f46;
-  box-shadow:0 10px 20px rgba(16,185,129,0.15);
-}
-.cal-controls .segmented [aria-pressed="false"] {
   background:#16a34a;
   color:#fff;
+  box-shadow:0 6px 14px rgba(16,185,129,0.2);
 }
-.cal-nav { display:flex; align-items:center; justify-content:center; gap:1rem; width:100%; }
+.cal-controls .segmented [aria-pressed="false"] {
+  background:#fff;
+  color:#16a34a;
+}
+.cal-nav { display:flex; align-items:center; justify-content:center; gap:1rem; flex:1 1 auto; min-width:0; }
 .cal-nav .cal-prev,
 .cal-nav .cal-next { position:static; transform:none; }
 
@@ -1189,12 +1194,12 @@ input[name="telefone"] { width:18ch; }
   color:#1f2937;
 }
 .cal-toolbar button, .cal-toolbar select, .cal-toolbar input { font:inherit; height:auto; }
-.cal-toolbar .btn { padding:0.5rem 1.25rem; }
+.cal-toolbar .btn { padding:0.5rem 1.25rem; border-radius:12px; }
 .btn-cal-eventos {
   background:#ff8a2a;
   color:#fff;
   font-weight:700;
-  border-radius:999px;
+  border-radius:12px;
   padding:0.55rem 1.5rem;
   border:none;
 }
@@ -1455,11 +1460,13 @@ input[name="telefone"] { width:18ch; }
 .switch:checked:before { transform:translateX(20px); }
 @media (max-width:768px){
   .cal-toolbar {
-    grid-template-columns:1fr;
-    row-gap:12px;
-    justify-items:stretch;
+    flex-wrap:wrap;
+    justify-content:flex-start;
+    gap:0.75rem;
   }
-  .cal-actions {
+  .cal-actions,
+  .cal-nav,
+  .cal-controls {
     width:100%;
   }
   .cal-actions .btn-cal-eventos {
@@ -1468,20 +1475,19 @@ input[name="telefone"] { width:18ch; }
   }
   .cal-nav {
     order:-1;
+    justify-content:flex-start;
   }
   .cal-controls {
-    justify-self:stretch;
-    flex-wrap:wrap;
     justify-content:flex-start;
+    flex-wrap:wrap;
     gap:0.5rem;
   }
   .cal-controls .cal-selects {
-    width:100%;
-    justify-content:space-between;
+    flex-wrap:wrap;
+    gap:0.5rem;
   }
   .cal-controls .segmented {
-    width:100%;
-    justify-content:space-between;
+    flex-wrap:wrap;
   }
 }
 


### PR DESCRIPTION
## Summary
- align the calendar toolbar controls on a single row while keeping the existing button order
- remove the bubble background from the right-hand controls and update button shapes to match rectangular styling
- correct the month/week toggle colors so the active option is green and improve responsive wrapping on smaller screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbfed81bdc8333823342dac0802b4a