### PR TITLE
Adjust calendar menu card styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -1234,21 +1234,43 @@ input[name="telefone"] { width:18ch; }
 .calendar-menu-bar .menu-widgets { display:grid; grid-template-columns:repeat(5, minmax(200px,1fr)); gap:clamp(6px,1vw,12px); align-items:stretch; width:100%; box-sizing:border-box; overflow-x:auto; }
 .calendar-menu-bar .menu-widgets::-webkit-scrollbar{height:6px;}
 .calendar-menu-bar .menu-widgets::-webkit-scrollbar-thumb{background:rgba(0,0,0,0.15);border-radius:999px;}
-.calendar-menu-bar .mini-widget { background:var(--surface); border:1px solid var(--color-border); border-radius:var(--radius-md); padding:clamp(4px,0.6vw,8px); display:flex; flex-direction:column; align-items:center; justify-content:center; min-height:clamp(32px,4vw,40px); box-sizing:border-box; overflow:hidden; text-align:center; gap:clamp(6px,0.9vw,9px); width:100%; }
+.calendar-menu-bar .mini-widget {
+  --mini-widget-bg: var(--surface);
+  --mini-widget-value-bg: #1f232a;
+  background:var(--mini-widget-bg);
+  border:1px solid var(--color-border);
+  border-radius:var(--radius-md);
+  padding:clamp(4px,0.6vw,8px);
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  min-height:clamp(32px,4vw,40px);
+  box-sizing:border-box;
+  overflow:hidden;
+  text-align:center;
+  gap:clamp(6px,0.9vw,9px);
+  width:100%;
+}
 .calendar-menu-bar .mini-title { font-weight:700; font-size:clamp(0.78rem,1.4vw,0.95rem); margin:0; text-align:center; word-break:break-word; }
 .calendar-menu-bar .mini-value { font-weight:700; text-align:center; font-size:clamp(1.05rem,2.8vw,1.6rem); }
 .calendar-menu-bar .mini-value,
 .calendar-menu-bar .mini-label { flex:0 0 auto; }
-.calendar-menu-bar .mini-split, .calendar-menu-bar .mini-triple {
+.calendar-menu-bar .mini-split,
+.calendar-menu-bar .mini-triple {
   display:grid;
   gap:clamp(4px,0.7vw,8px);
-  justify-items:stretch;
+  justify-items:center;
   align-items:stretch;
   grid-auto-rows:1fr;
   width:100%;
   box-sizing:border-box;
 }
-.calendar-menu-bar .mini-split { grid-template-columns:repeat(2, minmax(150px, 1fr)); }
+.calendar-menu-bar .mini-split {
+  grid-template-columns:repeat(2, minmax(0, 1fr));
+  max-width:clamp(180px, 70%, 240px);
+  margin:0 auto;
+}
 .calendar-menu-bar .mini-triple { grid-template-columns:repeat(3, minmax(0, 1fr)); }
 .calendar-menu-bar .mini-stat {
   display:flex;
@@ -1265,21 +1287,36 @@ input[name="telefone"] { width:18ch; }
 .calendar-menu-bar .mini-stat.mini-single{ max-width:220px; }
 .calendar-menu-bar .mini-label { font-size:clamp(0.7rem,1.2vw,0.85rem); font-weight:500; margin-top:clamp(2px,0.4vw,4px); display:block; line-height:1.2; }
 .calendar-menu-bar .mini-value {
-  background:#1f232a;
+  background:var(--mini-widget-value-bg);
   color:#fff;
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  padding:clamp(4px,0.6vw,6px) clamp(8px,1vw,12px);
-  border-radius:12px;
+  padding:clamp(4px,0.5vw,6px) clamp(6px,0.8vw,8px);
+  border-radius:10px;
   line-height:1;
-  min-width:clamp(32px,3vw,44px);
+  min-width:clamp(28px,2.4vw,36px);
   max-width:100%;
 }
-.calendar-menu-bar .mini-widget.mini-blue { background:#e3f2fd; }
-.calendar-menu-bar .mini-widget.mini-yellow { background:#fff8e1; }
-.calendar-menu-bar .mini-widget.mini-compact { background:#fff8e1; align-items:center; }
-.calendar-menu-bar .mini-widget.mini-actions-only { background:var(--surface); justify-content:flex-start; min-height:clamp(44px,6vw,56px); }
+.calendar-menu-bar .mini-widget.mini-blue {
+  --mini-widget-bg:#e3f2fd;
+  --mini-widget-value-bg:#bfd4ec;
+}
+.calendar-menu-bar .mini-widget.mini-yellow {
+  --mini-widget-bg:#fff8e1;
+  --mini-widget-value-bg:#e4d2a1;
+}
+.calendar-menu-bar .mini-widget.mini-compact {
+  --mini-widget-bg:#fff8e1;
+  --mini-widget-value-bg:#e4d2a1;
+  align-items:center;
+}
+.calendar-menu-bar .mini-widget.mini-actions-only {
+  --mini-widget-bg:var(--surface);
+  --mini-widget-value-bg:#1f232a;
+  justify-content:flex-start;
+  min-height:clamp(44px,6vw,56px);
+}
 .calendar-menu-bar .mini-widget.mini-actions-only .mini-actions-inline { display:flex; flex-direction:column; justify-content:center; gap:clamp(6px,0.9vw,9px); width:100%; box-sizing:border-box; }
 .calendar-menu-bar .mini-widget.mini-actions-only .mini-actions-inline button { width:100%; display:flex; align-items:center; justify-content:center; padding:clamp(8px,1vw,12px); }
 .calendar-menu-bar .mini-actions-inline { display:flex; align-items:center; justify-content:center; gap:var(--space-sm); width:100%; box-sizing:border-box; }


### PR DESCRIPTION
## Summary
- centraliza o conteúdo do card de contatos no menu do calendário para alinhar com os demais
- ajusta a cor de fundo e as dimensões dos indicadores numéricos conforme os cartões correspondentes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc3e03bc2c83338b66b712571aad6a