### PR TITLE
Align calendar menu bar and enhance follow-up chips

### DIFF
--- a/style.css
+++ b/style.css
@@ -1229,7 +1229,7 @@ input[name="telefone"] { width:18ch; }
 .segmented [aria-pressed="false"] { background:#fff; color:var(--color-text); }
 
 /* ===== Calendar Menu Bar ===== */
-.calendar-menu-bar { background:var(--surface); border-radius:var(--radius-lg); padding:clamp(12px,1.6vw,16px); display:flex; flex-direction:column; gap:clamp(10px,1.4vw,16px); align-items:stretch; margin:0 auto 1.5rem; width:100%; max-width:1200px; box-sizing:border-box; }
+.calendar-menu-bar { background:var(--surface); border-radius:var(--radius-lg); padding:clamp(12px,1.6vw,16px); display:flex; flex-direction:column; gap:clamp(10px,1.4vw,16px); align-items:stretch; margin:0 0 1.5rem; width:100%; max-width:none; box-sizing:border-box; }
 .calendar-menu-bar .menu-actions { display:flex; flex-wrap:wrap; gap:var(--space-sm); align-items:center; align-self:flex-start; flex:0 0 auto; }
 .calendar-menu-bar .menu-widgets { display:grid; grid-template-columns:repeat(5, minmax(200px,1fr)); gap:clamp(6px,1vw,12px); align-items:stretch; width:100%; box-sizing:border-box; overflow-x:auto; }
 .calendar-menu-bar .menu-widgets::-webkit-scrollbar{height:6px;}
@@ -1505,15 +1505,21 @@ input[name="telefone"] { width:18ch; }
   justify-content:flex-start;
   box-sizing:border-box;
 }
+.calendar-chip .chip-name { flex:1 1 auto; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.calendar-chip .chip-stage { flex:0 0 auto; border-radius:999px; padding:0.1rem 0.5rem; font-size:0.68rem; font-weight:700; letter-spacing:0.04em; text-transform:uppercase; }
+.calendar-chip.compra,
+.calendar-chip.evento.followup { justify-content:space-between; gap:0.5rem; }
+.calendar-chip.compra .chip-stage { background:rgba(255,255,255,0.25); color:#fff; }
+.calendar-chip.evento.followup .chip-stage { background:rgba(12,42,74,0.18); color:inherit; }
 .calendar-chip.compra { background:var(--color-primary); color:#fff; }
 .calendar-chip.evento { background:var(--accent-orange); color:#fff; padding-right:20px; }
 .calendar-chip.evento.admin { background:#9c27b0; color:#fff; }
-.calendar-chip.evento.followup { background:#bfe0ff; color:#0c2a4a; }
+.calendar-chip.evento.followup { background:#bfe0ff; color:#0c2a4a; padding-right:0.65rem; }
 .calendar-chip.evento[data-efetuado="false"]::after { content:""; position:absolute; right:0; top:0; width:14px; height:100%; background:var(--red-600); }
 .calendar-chip.evento[data-efetuado="true"]::after { display:none; }
 .calendar-chip.desfalque { background:#555; color:#fff; }
 .cal-ano, .cal-mes-select { min-height:auto; padding:0; border-radius:0; }
-.calendar-card {
+.calendar-card { 
   padding:0.75rem 1rem;
   border-radius:8px;
   background:#fff;
@@ -1531,6 +1537,7 @@ input[name="telefone"] { width:18ch; }
   align-items:flex-start;
   gap:0.35rem;
 }
+.calendar-card .stage-tag { margin-left:6px; }
 .calendar-card strong,
 .calendar-card p {
   overflow:hidden;


### PR DESCRIPTION
## Summary
- stretch the calendar menu bar to match the calendar card width regardless of viewport size
- reuse the purchase chip bubble layout for follow-up events, including compact client names and stage badges
- extend the follow-up popover with purchase details sourced from the related order

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc451b86ec8333958caf4adcef06c6