### PR TITLE
Adjust calendar chips and followup popover

### DIFF
--- a/script.js
+++ b/script.js
@@ -2343,15 +2343,15 @@ function initCalendarioPage() {
       if(telefone) rows.push(`<div class="popover-row"><span class="label">Telefone</span><span class="value">${telefone}</span></div>`);
       if(email) rows.push(`<div class="popover-row"><span class="label">Email</span><span class="value">${email}</span></div>`);
       if(compra?.dataCompra) rows.push(`<div class="popover-row"><span class="label">Compra</span><span class="value">${formatDateDDMMYYYY(compra.dataCompra)}</span></div>`);
-      if(compra?.nfe) rows.push(`<div class="popover-row"><span class="label">NFE/NFC-e</span><span class="value">${compra.nfe}</span></div>`);
-      if(valorHtml) rows.push(`<div class="popover-row"><span class="label">Valor</span><span class="value">${valorHtml}</span></div>`);
-      if(armacaoHtml) rows.push(`<div class="popover-row"><span class="label">Armação</span><span class="value">${armacaoHtml}</span></div>`);
-      if(compra?.lente) rows.push(`<div class="popover-row"><span class="label">Lente</span><span class="value">${compra.lente}</span></div>`);
-      if(tiposHtml) rows.push(`<div class="popover-row"><span class="label">Tipos</span><span class="value">${tiposHtml}</span></div>`);
+      rows.push(`<div class="popover-row"><span class="label">NFE/NFC-e</span><span class="value">${compra?.nfe || '-'}</span></div>`);
+      rows.push(`<div class="popover-row"><span class="label">Armação</span><span class="value">${armacaoHtml || '-'}</span></div>`);
+      rows.push(`<div class="popover-row"><span class="label">Lente</span><span class="value">${compra?.lente || '-'}</span></div>`);
+      rows.push(`<div class="popover-row"><span class="label">Tipos</span><span class="value">${tiposHtml || '-'}</span></div>`);
+      rows.push(`<div class="popover-row"><span class="label">Valor</span><span class="value">${valorHtml || '-'}</span></div>`);
       if(observacoesHtml) rows.push(`<div class="popover-row"><span class="label">Observações</span><span class="value">${observacoesHtml}</span></div>`);
       const bodyHtml = rows.join('');
       const doneAttr = ev.meta?.done ? 'checked' : '';
-      const bodySection = bodyHtml ? `<div class="pop-divider"></div><div class="popover-body">${bodyHtml}</div>` : '';
+      const bodySection = bodyHtml ? `<div class="popover-body">${bodyHtml}</div>` : '';
       const stageTag = stageLabel ? ` <span class="tag">${stageLong || stageLabel}</span>` : '';
       pop.innerHTML=`<div class="pop-head"><span class="pop-date">${followupDate}</span></div>`
         +`<div class="pop-title">${shortName || (ev.title || '')}${stageTag}</div>`

--- a/style.css
+++ b/style.css
@@ -1477,8 +1477,8 @@ input[name="telefone"] { width:18ch; }
 .calendar-item {
   display:flex;
   align-items:center;
-  gap:0.5rem;
-  margin-top:0.5rem;
+  gap:0.35rem;
+  margin-top:0.4rem;
   min-width:0;
   width:100%;
 }
@@ -1507,13 +1507,14 @@ input[name="telefone"] { width:18ch; }
 .calendar-chip .chip-name { flex:1 1 auto; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .calendar-chip .chip-stage { flex:0 0 auto; border-radius:999px; padding:0.1rem 0.5rem; font-size:0.68rem; font-weight:700; letter-spacing:0.04em; text-transform:uppercase; }
 .calendar-chip.compra,
-.calendar-chip.evento.followup { justify-content:space-between; gap:0.5rem; }
+.calendar-chip.evento.followup { justify-content:space-between; gap:0.35rem; }
 .calendar-chip.compra .chip-stage { background:rgba(255,255,255,0.25); color:#fff; }
 .calendar-chip.evento.followup .chip-stage { background:rgba(12,42,74,0.18); color:inherit; }
 .calendar-chip.compra { background:var(--color-primary); color:#fff; }
 .calendar-chip.evento { background:var(--accent-orange); color:#fff; padding-right:20px; }
 .calendar-chip.evento.admin { background:#9c27b0; color:#fff; }
-.calendar-chip.evento.followup { background:#bfe0ff; color:#0c2a4a; padding-right:0.65rem; }
+.calendar-chip.evento.followup { background:#bfe0ff; color:#0c2a4a; padding-right:calc(0.65rem + 14px); }
+.calendar-chip.evento.followup .chip-stage { margin-right:0.35rem; }
 .calendar-chip.evento[data-efetuado="false"]::after { content:""; position:absolute; right:0; top:0; width:14px; height:100%; background:var(--red-600); }
 .calendar-chip.evento[data-efetuado="true"]::after { display:none; }
 .calendar-chip.desfalque { background:#555; color:#fff; }


### PR DESCRIPTION
## Summary
- tighten calendar chip spacing and add extra padding to keep follow-up stages clear of the red status bar
- expand follow-up popover details with consistent rows for fiscal and product fields and remove the divider before the body content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc5058ae68833392ee899ab21ad790