### PR TITLE
Ajusta menu lateral com popovers e subpáginas de calendário

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,18 @@
     <div class="sidebar-nav" role="presentation">
       <ul>
       <li class="nav-item" data-route="dashboard" tabindex="0"><span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg></span><span class="label">Dashboard</span></li>
-      <li class="nav-item" data-route="calendario" tabindex="0"><span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg></span><span class="label">Calendario</span></li>
+      <li class="nav-group" data-root="calendario">
+        <div class="nav-item has-submenu" data-route="calendario" data-root="calendario" data-submenu-enabled="false" aria-expanded="false" tabindex="0">
+          <span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg></span>
+          <span class="label">Calendário</span>
+          <span class="submenu-caret" aria-hidden="true">▸</span>
+        </div>
+        <ul class="nav-submenu" aria-label="Submenu Calendário" hidden>
+          <li class="nav-subitem" data-parent="calendario" data-route="calendario" tabindex="0"><span class="label">Calendário geral</span></li>
+          <li class="nav-subitem" data-parent="calendario" data-route="calendario-folgas" tabindex="0"><span class="label">Folgas</span></li>
+          <li class="nav-subitem" data-parent="calendario" data-route="calendario-visualizador" tabindex="0"><span class="label">Visualizador de calendários</span></li>
+        </ul>
+      </li>
       <li class="nav-group" data-root="clientes">
         <div class="nav-item has-submenu" data-route="clientes" data-root="clientes" data-default-route="clientes-visao-geral" aria-expanded="false" tabindex="0">
           <span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="7" r="4"></circle><path d="M5.5 21a8.38 8.38 0 0 1 13 0"></path></svg></span>

--- a/style.css
+++ b/style.css
@@ -241,16 +241,8 @@ a { color: inherit; text-decoration: none; }
   padding-right: 16px;
   margin-inline: 16px;
 }
-.sidebar:not(.is-expanded) .nav-submenu {
-  max-height: 0;
-  overflow: hidden;
-  padding: 0;
-}
-.sidebar .nav-submenu {
-  transition: max-height 0.2s ease;
-}
-.sidebar.is-expanded .nav-group.is-expanded .nav-submenu {
-  max-height: 400px;
+.sidebar .nav-submenu[hidden] {
+  display: none !important;
 }
 .nav-item.is-active {
   background: #2A2F37;
@@ -284,9 +276,8 @@ a { color: inherit; text-decoration: none; }
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 16px 0 56px;
+  padding: 0 16px;
   min-height: var(--sidebar-item-height);
-  height: var(--sidebar-item-height);
   line-height: var(--sidebar-item-height);
   color: #ccc;
   cursor: pointer;
@@ -1880,21 +1871,42 @@ input[name="telefone"] { width:18ch; }
   margin: 0 16px;
   border-radius: var(--radius-md);
 }
+.nav-group {
+  position: relative;
+}
 .nav-submenu {
   list-style: none;
-  margin: 4px 16px 0;
-  padding: 6px 0;
+  margin: 0;
+  padding: 8px 0;
   display: none;
   flex-direction: column;
   background: var(--sidebar-sub-bg);
   border-radius: var(--radius-md);
-  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1);
+  box-shadow: 0 12px 32px rgba(0,0,0,0.35);
+  position: fixed;
+  left: var(--sidebar-collapsed-w);
+  top: 0;
+  min-width: 200px;
+  z-index: 1000;
 }
-.nav-group.is-expanded .nav-submenu {
+.nav-submenu::before {
+  content: '';
+  position: absolute;
+  left: -6px;
+  top: var(--submenu-anchor-offset, calc(50% - 6px));
+  width: 12px;
+  height: 12px;
+  background: inherit;
+  transform: rotate(45deg);
+  box-shadow: -3px 3px 8px rgba(0,0,0,0.25);
+  border-radius: 2px;
+}
+.nav-group.is-popover-open .nav-submenu {
   display: flex;
 }
-.nav-group.is-expanded > .nav-item {
-  border-bottom: none;
+.nav-group.is-popover-open > .nav-item {
+  background: #2A2F37;
+  color: #fff;
 }
 .nav-group.is-highlighted {
   background: transparent;
@@ -1911,4 +1923,23 @@ input[name="telefone"] { width:18ch; }
 }
 .nav-group:not(.is-highlighted) .nav-subitem.is-active {
   background: #2A2F37;
+}
+.nav-tooltip {
+  position: fixed;
+  padding: 6px 12px;
+  background: rgba(24, 29, 38, 0.96);
+  color: #fff;
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-50%) scale(0.95);
+  transform-origin: left center;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 1200;
+}
+.nav-tooltip.is-visible {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
 }


### PR DESCRIPTION
## Summary
- reestrutura o item de calendário para suportar submenu com páginas específicas do administrador
- implementa popovers e tooltips no menu lateral mantendo o menu compacto
- adiciona páginas em branco para Folgas e Visualizador de calendários

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd5d757e8483338de831ef9a747e09