### PR TITLE
Ajusta posição e largura do submenu lateral

### DIFF
--- a/script.js
+++ b/script.js
@@ -900,11 +900,18 @@ function positionSubmenu(item, submenu){
   const submenuRect = submenu.getBoundingClientRect();
   const margin = 16;
   const viewportHeight = window.innerHeight;
+  const viewportWidth = window.innerWidth;
   let top = rect.top + rect.height / 2 - submenuRect.height / 2;
   const maxTop = viewportHeight - submenuRect.height - margin;
   const minTop = margin;
   top = Math.min(Math.max(top, minTop), Math.max(minTop, maxTop));
   submenu.style.top = `${top}px`;
+  const horizontalGap = 12;
+  let left = rect.right + horizontalGap;
+  const maxLeft = viewportWidth - submenuRect.width - margin;
+  const minLeft = margin;
+  left = Math.min(Math.max(left, minLeft), Math.max(minLeft, maxLeft));
+  submenu.style.left = `${left}px`;
   const updatedRect = submenu.getBoundingClientRect();
   const anchorCenter = rect.top + rect.height / 2;
   let arrowOffset = anchorCenter - updatedRect.top - 6;
@@ -935,6 +942,7 @@ function setNavSubmenuState(item, expanded){
     group.classList.remove('is-popover-open');
     submenu.hidden = true;
     submenu.style.top = '';
+    submenu.style.left = '';
     submenu.style.removeProperty('--submenu-anchor-offset');
     if(activeNavPopover && activeNavPopover.item === item) activeNavPopover = null;
   }

--- a/style.css
+++ b/style.css
@@ -47,8 +47,8 @@
   --space-lg: 24px;
   --sidebar-item-height: 44px; /* Ajuste: altura fixa para itens do menu lateral */
   /* Floating menu tokens */
-  --menu-popover-min-width: 180px;
-  --menu-popover-max-width: 320px;
+  --menu-popover-min-width: 176px;
+  --menu-popover-max-width: 260px;
   --menu-popover-max-height: 360px;
   /* White balloon tokens */
   --balloon-bg: var(--surface);


### PR DESCRIPTION
## Summary
- torna o cálculo de posição do submenu lateral dependente do espaço visível, evitando que ele fique oculto pela viewport
- redefine as variáveis de largura do popover para deixar o submenu mais compacto

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd6a0cdff483338ff5a5e9d85f72fe