### PR TITLE
Adjust submenu positioning clamp for small viewports

### DIFF
--- a/script.js
+++ b/script.js
@@ -903,7 +903,11 @@ function positionSubmenu(item, submenu){
   let top = rect.top + rect.height / 2 - submenuRect.height / 2;
   const maxTop = viewportHeight - submenuRect.height - margin;
   const minTop = margin;
-  top = Math.min(Math.max(top, minTop), Math.max(minTop, maxTop));
+  if(maxTop >= minTop){
+    top = Math.min(Math.max(top, minTop), Math.max(minTop, maxTop));
+  } else {
+    top = Math.max(0, viewportHeight - submenuRect.height);
+  }
   submenu.style.top = `${top}px`;
   const updatedRect = submenu.getBoundingClientRect();
   const anchorCenter = rect.top + rect.height / 2;


### PR DESCRIPTION
## Summary
- update submenu positioning logic to relax margin constraints when the submenu cannot fit between margins
- ensure the submenu stays within the viewport height by anchoring it to the bottom edge in constrained cases

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cda3ef99388333840bd88a267cea0d