### PR TITLE
Ensure sidebar submenu overlays interface

### DIFF
--- a/style.css
+++ b/style.css
@@ -1898,7 +1898,7 @@ input[name="telefone"] { width:18ch; }
   max-width: min(var(--menu-popover-max-width), calc(100vw - var(--sidebar-collapsed-w) - 32px));
   max-height: min(var(--menu-popover-max-height), calc(100vh - 48px));
   overflow-y: auto;
-  z-index: 2000;
+  z-index: 12000;
   box-sizing: border-box;
 }
 .nav-submenu::before {


### PR DESCRIPTION
## Summary
- increase the sidebar submenu z-index so it always displays above other interface layers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cda544f3ec83339d6a1d53b8b5fa34