### PR TITLE
Add client status indicators and reorganize contacts and gerencia pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,30 @@
         </ul>
       </li>
       <li class="nav-item" data-route="os" tabindex="0"><span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg></span><span class="label">Ordem de Serviço</span></li>
-      <li class="nav-item" data-route="contato" tabindex="0"><span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"></polyline><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path></svg></span><span class="label">Contato a ser executado</span></li>
-      <li class="nav-item" data-route="gerencia" tabindex="0"><span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg></span><span class="label">Gerencia</span></li>
+      <li class="nav-group" data-root="contatos">
+        <div class="nav-item has-submenu" data-route="contatos" data-root="contatos" data-default-route="contatos-executar" aria-expanded="false" tabindex="0">
+          <span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"></polyline><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path></svg></span>
+          <span class="label">Contatos</span>
+          <span class="submenu-caret" aria-hidden="true">▸</span>
+        </div>
+        <ul class="nav-submenu" aria-label="Submenu Contatos">
+          <li class="nav-subitem" data-parent="contatos" data-route="contatos-executar" tabindex="0"><span class="label">Contatos a Executar</span></li>
+          <li class="nav-subitem" data-parent="contatos" data-route="contatos-listas" tabindex="0"><span class="label">Listas de Contatos</span></li>
+          <li class="nav-subitem" data-parent="contatos" data-route="contatos-pos-venda" tabindex="0"><span class="label">Pós Venda</span></li>
+          <li class="nav-subitem" data-parent="contatos" data-route="contatos-ofertas" tabindex="0"><span class="label">Ofertas</span></li>
+        </ul>
+      </li>
+      <li class="nav-group" data-root="gerencia">
+        <div class="nav-item has-submenu" data-route="gerencia" data-root="gerencia" data-default-route="gerencia-config" aria-expanded="false" tabindex="0">
+          <span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg></span>
+          <span class="label">Gerencia</span>
+          <span class="submenu-caret" aria-hidden="true">▸</span>
+        </div>
+        <ul class="nav-submenu" aria-label="Submenu Gerencia">
+          <li class="nav-subitem" data-parent="gerencia" data-route="gerencia-config" tabindex="0"><span class="label">Configurações do Perfil</span></li>
+          <li class="nav-subitem" data-parent="gerencia" data-route="gerencia-mensagens" tabindex="0"><span class="label">Mensagens para Clientes</span></li>
+        </ul>
+      </li>
       <li class="nav-item nav-config" data-route="configuracoes" tabindex="0" style="display:none"><span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09A1.65 1.65 0 0 0 10 4.6V4a2 2 0 1 1 4 0v.09c0 .69.4 1.31 1 1.6.53.26 1.14.24 1.62-.07l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06c-.31.48-.33 1.09-.07 1.62.29.6.91 1 1.6 1H21a2 2 0 1 1 0 4h-.09c-.69 0-1.31.4-1.6 1z"></path></svg></span><span class="label">Configurações</span></li>
       </ul>
     </div>

--- a/script.js
+++ b/script.js
@@ -657,6 +657,7 @@ function removeFollowUpEvents(clienteId,compraId){
       genero: payload.genero || '',
       observacoes: payload.observacoes || '',
       interesses: payload.interesses || [],
+      naoContate: Boolean(payload.naoContate),
       compras: [],
       criadoEm: now,
       atualizadoEm: now
@@ -857,13 +858,19 @@ const routes = {
   'clientes-tabela': renderClientesTabela,
   'clientes-pagina': renderClientePagina,
   os: renderOS,
-  contato: renderContato,
-  gerencia: renderGerencia,
+  'contatos-executar': renderContatosExecutar,
+  'contatos-listas': renderContatosListas,
+  'contatos-pos-venda': renderContatosPosVenda,
+  'contatos-ofertas': renderContatosOfertas,
+  'gerencia-config': renderGerenciaConfig,
+  'gerencia-mensagens': renderGerenciaMensagens,
   configuracoes: renderConfig
 };
 const CLIENTES_SUBROUTES = new Set(['clientes-visao-geral','clientes-cadastro','clientes-tabela','clientes-pagina']);
 const CALENDARIO_SUBROUTES = new Set(['calendario','calendario-folgas','calendario-visualizador']);
-const SUBMENU_ROUTES = { clientes: CLIENTES_SUBROUTES, calendario: CALENDARIO_SUBROUTES };
+const CONTATOS_SUBROUTES = new Set(['contatos-executar','contatos-listas','contatos-pos-venda','contatos-ofertas']);
+const GERENCIA_SUBROUTES = new Set(['gerencia-config','gerencia-mensagens']);
+const SUBMENU_ROUTES = { clientes: CLIENTES_SUBROUTES, calendario: CALENDARIO_SUBROUTES, contatos: CONTATOS_SUBROUTES, gerencia: GERENCIA_SUBROUTES };
 
 function routeMatchesRoot(root, route){
   const set = SUBMENU_ROUTES[root];
@@ -974,7 +981,7 @@ function collapseAllSubmenus(exceptRoot){
   });
   hideNavTooltip();
 }
-const routeAliases = { clientes: 'clientes-visao-geral' };
+const routeAliases = { clientes: 'clientes-visao-geral', contatos: 'contatos-executar', contato: 'contatos-executar', gerencia: 'gerencia-config' };
 let currentRoute = 'dashboard';
 
 function resolveRoute(name){
@@ -1000,8 +1007,12 @@ function renderRoute(name){
     'clientes-tabela': 'Clientes · Tabela de Clientes',
     'clientes-pagina': 'Clientes · Página do Cliente',
     os: 'Ordem de Serviço',
-    contato: 'Contato a ser executado',
-    gerencia: 'Gerencia',
+    'contatos-executar': 'Contatos · Contatos a Executar',
+    'contatos-listas': 'Contatos · Listas de Contatos',
+    'contatos-pos-venda': 'Contatos · Pós Venda',
+    'contatos-ofertas': 'Contatos · Ofertas',
+    'gerencia-config': 'Gerencia · Configurações do Perfil',
+    'gerencia-mensagens': 'Gerencia · Mensagens para Clientes',
     configuracoes: 'Configurações'
   };
   const pageTitle = titles[currentRoute] || titles[routeAliases[currentRoute]] || currentRoute;
@@ -1031,7 +1042,8 @@ function renderRoute(name){
   if(currentRoute === 'clientes-pagina') initClientePagina();
   if(currentRoute === 'calendario') initCalendarioPage();
   if(currentRoute === 'os') initOSPage();
-  if(currentRoute === 'gerencia') initGerenciaPage();
+  if(currentRoute === 'gerencia-config') initGerenciaConfigPage();
+  if(currentRoute === 'gerencia-mensagens') initGerenciaMensagensPage();
   if(currentRoute === 'configuracoes') initConfiguracoesPage();
   updateProfileUI();
 }
@@ -1478,11 +1490,35 @@ function dashboardPage() {
   `</section>`;
 }
 
-function renderContato() {
-  return renderCardGrid('Contato');
+function renderContatosPlaceholder(title, slug){
+  return `
+  <section class="contatos-page contatos-${slug}">
+    <div class="card-grid">
+      <div class="card" data-card-id="contatos-${slug}" data-colspan="12">
+        <div class="card-header"><div class="card-head">${title}</div></div>
+        <div class="card-body"><div class="empty-state">Conteúdo em preparação.</div></div>
+      </div>
+    </div>
+  </section>`;
 }
 
-function renderGerencia() {
+function renderContatosExecutar(){
+  return renderContatosPlaceholder('Contatos a Executar','executar');
+}
+
+function renderContatosListas(){
+  return renderContatosPlaceholder('Listas de Contatos','listas');
+}
+
+function renderContatosPosVenda(){
+  return renderContatosPlaceholder('Pós Venda','pos-venda');
+}
+
+function renderContatosOfertas(){
+  return renderContatosPlaceholder('Ofertas','ofertas');
+}
+
+function renderGerenciaConfig() {
   return `
   <div class="card-grid">
     <div class="card" data-card-id="loja" data-colspan="6" data-rowspan="2">
@@ -1543,6 +1579,26 @@ function renderConfig() {
     <div class="card empty-state" data-card-id="ph3"></div>
     <div class="card empty-state" data-card-id="ph4"></div>
   </div>`;
+}
+
+function renderGerenciaMensagens(){
+  return `
+  <section id="gerenciaMensagens" class="gerencia-mensagens">
+    <div class="mensagens-tabs" role="tablist">
+      <button type="button" class="mensagem-tab is-active" data-tab="pos-venda">Pós Venda</button>
+      <button type="button" class="mensagem-tab" data-tab="ofertas">Ofertas</button>
+    </div>
+    <div class="card-grid mensagens-grid">
+      <div class="card mensagens-card" data-colspan="12" data-tab-content="pos-venda">
+        <div class="card-header"><div class="card-head">Pós Venda</div></div>
+        <div class="card-body"><div class="empty-state">Conteúdo em preparação.</div></div>
+      </div>
+      <div class="card mensagens-card" data-colspan="12" data-tab-content="ofertas" hidden>
+        <div class="card-header"><div class="card-head">Ofertas</div></div>
+        <div class="card-body"><div class="empty-state">Conteúdo em preparação.</div></div>
+      </div>
+    </div>
+  </section>`;
 }
 
 // ===== Helpers =====
@@ -1616,6 +1672,71 @@ const FOLLOWUP_PERIODS=['3m','6m','12m'];
 const FOLLOWUP_OFFSETS={ '3m':90, '6m':180, '12m':365 };
 const FOLLOWUP_LABELS={ '3m':'3 meses','6m':'6 meses','12m':'12 meses' };
 
+function escapeHtml(str=''){
+  return String(str)
+    .replace(/&/g,'&amp;')
+    .replace(/</g,'&lt;')
+    .replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;')
+    .replace(/'/g,'&#39;');
+}
+
+const CLIENT_STATUS={
+  POS_VENDA:{ key:'pos-venda', label:'PÓS VENDA' },
+  LISTA_OFERTAS:{ key:'lista-ofertas', label:'LISTA DE OFERTAS' },
+  NAO_CONTATE:{ key:'nao-contate', label:'NÃO CONTATE' }
+};
+
+const DAY_IN_MS=24*60*60*1000;
+
+function toSafeDate(value){
+  if(!value) return null;
+  if(value instanceof Date){
+    return isNaN(value.getTime())?null:value;
+  }
+  if(typeof value==='string' && value.includes('/')){
+    const parsed=parseDDMMYYYY(value);
+    return isNaN(parsed.getTime())?null:parsed;
+  }
+  const date=new Date(value);
+  return isNaN(date.getTime())?null:date;
+}
+
+function compraTemFollowupPendente(compra){
+  if(!compra) return false;
+  const followUps=compra.followUps || {};
+  return FOLLOWUP_PERIODS.some(period=>!followUps[period]?.done);
+}
+
+function getClientStatus(cliente){
+  if(!cliente) return CLIENT_STATUS.LISTA_OFERTAS;
+  if(cliente.naoContate) return CLIENT_STATUS.NAO_CONTATE;
+  const compras=cliente.compras || [];
+  if(!compras.length) return CLIENT_STATUS.LISTA_OFERTAS;
+  const now=Date.now();
+  const hasPending=compras.some(compra=>{
+    const date=toSafeDate(compra?.dataCompra || compra?.dataISO);
+    if(!date) return false;
+    const diff=(now-date.getTime())/DAY_IN_MS;
+    if(diff>365) return false;
+    return compraTemFollowupPendente(compra);
+  });
+  return hasPending ? CLIENT_STATUS.POS_VENDA : CLIENT_STATUS.LISTA_OFERTAS;
+}
+
+function renderClientStatusBadge(cliente){
+  const status=getClientStatus(cliente);
+  if(!status) return '';
+  return `<span class="client-status-badge client-status-${status.key}" aria-label="${status.label}">${status.label}</span>`;
+}
+
+function renderClientNameInline(cliente){
+  const rawName=cliente?.nome;
+  const name=escapeHtml(rawName || 'Cliente');
+  const badge=renderClientStatusBadge(cliente);
+  return `<span class="client-name-with-status">${badge}<span class="client-name-text">${name}</span></span>`;
+}
+
 function buildFollowupBadges(cp){
   const followUps=cp?.followUps || {};
   const badges=FOLLOWUP_PERIODS.map(period=>{
@@ -1679,6 +1800,14 @@ function clienteFormTemplate({ includeObservacoes=false, includePurchaseSection=
                 <button type="button" class="chip" data-value="BIFOCAL" aria-pressed="false">BIFOCAL</button>
                 <button type="button" class="chip" data-value="SOLAR" aria-pressed="false">SOLAR</button>
               </div>
+            </div>
+            <div class="form-field col-span-4">
+              <span class="field-label">Preferência de contato</span>
+              <label class="contact-pref">
+                <input type="checkbox" id="cliente-nao-contate" class="switch">
+                <span>Não contatar</span>
+              </label>
+              <small class="field-hint">Marque quando o cliente optar por não receber contato.</small>
             </div>
             ${includeObservacoes ? '<div class="form-field col-span-12"><label for="cliente-observacoes">Observações</label><textarea id="cliente-observacoes" name="observacoes" class="textarea" rows="4"></textarea></div>' : ''}
           </div>
@@ -1777,6 +1906,11 @@ function initClienteForm(form, { cliente=null, includePurchaseSection=true }={})
     });
   }
 
+  const naoContateInput=form.querySelector('#cliente-nao-contate');
+  if(naoContateInput){
+    naoContateInput.checked=!!cliente?.naoContate;
+  }
+
   const generoDiv=form.querySelector('#cliente-genero');
   if(generoDiv){
     const generoButtons=Array.from(generoDiv.querySelectorAll('button'));
@@ -1835,6 +1969,8 @@ function initClienteForm(form, { cliente=null, includePurchaseSection=true }={})
       if(dataNascimento) dataNascimento.value='';
       if(cpfInput) cpfInput.value='';
       if(obsInput) obsInput.value='';
+      const naoContate=form.querySelector('#cliente-nao-contate');
+      if(naoContate) naoContate.checked=false;
       form.querySelectorAll('#cliente-interesses button').forEach(btn=>btn.setAttribute('aria-pressed','false'));
       form.querySelectorAll('#cliente-genero .seg-btn').forEach(btn=>btn.setAttribute('aria-pressed','false'));
       if(includePurchaseSection){
@@ -2766,7 +2902,7 @@ function initClientesVisaoGeral() {
         tr.dataset.id = c.id;
         const compra = getUltimaCompra(c.compras);
         tr.innerHTML = `
-            <td>${c.nome}</td>
+            <td>${renderClientNameInline(c)}</td>
             <td>${formatTelefone(c.telefone)}</td>
             <td>${compra ? formatDateDDMMYYYY(compra.dataCompra) : '-'}</td>`;
         if (selecionado === c.id) {
@@ -2804,7 +2940,7 @@ function initClientesVisaoGeral() {
       detail.innerHTML = `
         <div class="mini-card client-overview">
           <div class="overview-header">
-            <h2>${c.nome}</h2>
+            <h2>${renderClientNameInline(c)}</h2>
             <div class="actions">
               <button class="btn btn-outline btn-cliente-page" type="button">Página do Cliente</button>
               <button class="btn-icon adjust btn-edit-detalhe" aria-label="Editar Cliente" title="Editar Cliente">${iconEdit}</button>
@@ -2817,6 +2953,7 @@ function initClientesVisaoGeral() {
           <div class="info-label">CPF</div><div class="info-value">${c.cpf ? formatCpf(c.cpf) : '-'}</div>
           <div class="info-label">Gênero</div><div class="info-value">${c.genero || '-'}</div>
           <div class="info-label">Interesses</div><div class="info-value">${((c.interesses||c.usos) && (c.interesses||c.usos).length)?(c.interesses||c.usos).join(', '):'-'}</div>
+          <div class="info-label">Preferência de contato</div><div class="info-value">${c.naoContate ? 'Não contatar' : 'Aceita contato'}</div>
         </div>
       </div>
         <div class="mini-card">
@@ -3047,13 +3184,14 @@ function initClientesTabela(){
     return `
       <div class="client-detail-modal">
         <div class="mini-card client-overview">
-          <h2>${cliente.nome}</h2>
+          <h2>${renderClientNameInline(cliente)}</h2>
           <div class="dados-pessoais info-grid">
             <div class="info-label">Telefone</div><div class="info-value">${telefone}</div>
             <div class="info-label">Nascimento</div><div class="info-value">${nascimento||'-'}</div>
             <div class="info-label">CPF</div><div class="info-value">${cpf}</div>
             <div class="info-label">Gênero</div><div class="info-value">${genero}</div>
             <div class="info-label">Interesses</div><div class="info-value">${interesses}</div>
+            <div class="info-label">Preferência de contato</div><div class="info-value">${cliente.naoContate ? 'Não contatar' : 'Aceita contato'}</div>
           </div>
         </div>
         <div class="mini-card">
@@ -3103,7 +3241,7 @@ function initClientesTabela(){
     if(cancelBtn.getAttribute('data-action')) cancelBtn.removeAttribute('data-action');
     cancelBtn.setAttribute('type','button');
     dialog.classList.add('modal-cliente-detalhe');
-    title.textContent=cliente.nome;
+    title.innerHTML=renderClientNameInline(cliente);
     body.innerHTML=buildClientDetailModalHTML(cliente);
     const originalClose=modal.close.bind(modal);
     modal.close=()=>{
@@ -3259,7 +3397,7 @@ function initClientesTabela(){
         }).join('');
         return `<tr data-id="${c.id}"${isSelected?' class="row-selected"':''} tabindex="0">`
           +`<td class="select-cell select-col"><input type="checkbox" class="client-select-row" data-id="${c.id}" ${isSelected?'checked':''} aria-label="Selecionar cliente"></td>`
-          +`<td data-field="nome">${c.nome}</td>`
+          +`<td data-field="nome">${renderClientNameInline(c)}</td>`
           +`<td data-field="telefone">${telefone}</td>`
           +`<td data-field="cpf">${cpf}</td>`
           +`<td data-field="genero">${genero}</td>`
@@ -3415,7 +3553,7 @@ function initClientePagina(){
   }
 
   function updateHeader(){
-    if(titleEl) titleEl.textContent=cliente.nome || 'Cliente';
+    if(titleEl) titleEl.innerHTML=renderClientNameInline(cliente);
     if(subtitleEl){
       const parts=[];
       const compras=cliente.compras||[];
@@ -3455,6 +3593,7 @@ function initClientePagina(){
         <div><dt>Email</dt><dd>${email}</dd></div>
         <div><dt>Endereço</dt><dd>${endereco}</dd></div>
         <div><dt>Interesses</dt><dd>${interesses}</dd></div>
+        <div><dt>Preferência de contato</dt><dd>${cliente.naoContate ? 'Não contatar' : 'Aceita contato'}</dd></div>
       </dl>
       ${observacoes}`;
   }
@@ -3756,38 +3895,27 @@ document.addEventListener('click', (e)=>{
   if(dashMenu && !dashMenu.hidden && !dashMenu.contains(e.target) && e.target !== dashBtn) closeDashMenu();
 });
 
-function initGerenciaPage(){
-  const main=document.getElementById('app-main');
-  if(main) main.innerHTML='';
-  const modal=document.getElementById('app-modal');
-  const title=document.getElementById('modal-title');
-  const body=modal.querySelector('.modal-body');
-  function openPrompt(){
-    const saveBtn = modal.querySelector('#modal-save');
-    saveBtn.removeAttribute('data-action');
-    saveBtn.setAttribute('type','submit');
-    title.textContent='Senha';
-    body.innerHTML=`<form id="gerencia-form"><div class="form-field col-span-12"><label for="gerencia-pass">Senha</label><input id="gerencia-pass" type="password" class="text-input" required></div></form>`;
-    saveBtn.setAttribute('form','gerencia-form');
-    modal.open();
-    body.querySelector('#gerencia-form').addEventListener('submit',e=>{
-      e.preventDefault();
-      const val=body.querySelector('#gerencia-pass').value;
-      if(val==='12345'){
-        modal.close();
-        if(main){
-          main.innerHTML=renderGerencia();
-          cards.apply(main);
-          cards.loading(main);
-          initLojaConfig();
-          initConfiguracoesPage();
-        }
-      } else {
-        alert('Senha inválida');
-      }
+function initGerenciaConfigPage(){
+  initLojaConfig();
+  initConfiguracoesPage();
+}
+
+function initGerenciaMensagensPage(){
+  const container=document.getElementById('gerenciaMensagens');
+  if(!container) return;
+  const tabs=Array.from(container.querySelectorAll('.mensagem-tab'));
+  const panels=new Map(Array.from(container.querySelectorAll('[data-tab-content]')).map(panel=>[panel.dataset.tabContent,panel]));
+  function activate(tab){
+    const target=tab || tabs[0]?.dataset.tab;
+    tabs.forEach(btn=>{
+      btn.classList.toggle('is-active', btn.dataset.tab===target);
+    });
+    panels.forEach((panel,key)=>{
+      panel.hidden=key!==target;
     });
   }
-  openPrompt();
+  tabs.forEach(btn=>btn.addEventListener('click',()=>activate(btn.dataset.tab)));
+  activate(container.querySelector('.mensagem-tab.is-active')?.dataset.tab);
 }
 
 function initConfiguracoesPage(){
@@ -3962,6 +4090,9 @@ function readClientForm(){
     genero: document.querySelector('#cliente-genero .seg-btn[aria-pressed="true"]')?.dataset.value || '',
     interesses: getSelectedInteressesFromForm()
   };
+
+  const naoContateEl=document.getElementById('cliente-nao-contate');
+  if(naoContateEl) formData.naoContate=naoContateEl.checked;
 
   const obsEl = document.getElementById('cliente-observacoes');
   if(obsEl) formData.observacoes = obsEl.value.trim();

--- a/style.css
+++ b/style.css
@@ -1066,6 +1066,77 @@ input[name="telefone"] { width:18ch; }
 .cliente-contatos-table .contato-status { text-align:center; }
 .cliente-contatos-table .contato-switch { display:inline-flex; align-items:center; gap:var(--space-sm); cursor:pointer; }
 .cliente-contatos-table .contato-switch input { width:18px; height:18px; }
+
+/* ===== Client status and contact preferences ===== */
+.client-name-with-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+.client-name-text { font-weight: inherit; }
+.client-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  color: #fff;
+  white-space: nowrap;
+  line-height: 1;
+}
+.client-status-pos-venda { background: var(--green-500); }
+.client-status-lista-ofertas { background: #1565c0; }
+.client-status-nao-contate { background: var(--red-600); }
+
+.contact-pref {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-weight: 500;
+}
+.contact-pref .switch { flex-shrink: 0; }
+.field-hint {
+  display: block;
+  margin-top: var(--space-xs);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+/* ===== Gerencia mensagens tabs ===== */
+.gerencia-mensagens .mensagens-tabs {
+  display: flex;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+}
+.gerencia-mensagens .mensagem-tab {
+  border: 1px solid var(--color-border);
+  background: var(--surface);
+  color: var(--text-primary);
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.gerencia-mensagens .mensagem-tab.is-active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+.gerencia-mensagens .mensagens-grid {
+  grid-template-columns: repeat(12, 1fr);
+}
+.gerencia-mensagens .mensagens-card {
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+}
 .modal-client-page-btn { margin-right:auto; text-transform:uppercase; font-weight:600; }
 .btn-cliente-page { margin-right:var(--space-sm); }
 


### PR DESCRIPTION
## Summary
- classify clients into pós venda, lista de ofertas, or não contate based on follow-ups and opt-out flag and show the status beside names
- add a "não contatar" preference to the client form and propagate the badge across tables, detail views, and modals
- restructure navigation to introduce Contatos subpages, split Gerencia into Configurações do Perfil and Mensagens para Clientes, and add placeholder layouts and tabs for the new pages
- remove the Gerencia password gate and style new UI elements, including status badges and messaging tabs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdbadf8d5c833397e80238dec92de2