### PR TITLE
Add Contatos histórico toggle page and rename gerencia subpages

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
           <li class="nav-subitem" data-parent="contatos" data-route="contatos-listas" tabindex="0"><span class="label">Listas de Contatos</span></li>
           <li class="nav-subitem" data-parent="contatos" data-route="contatos-pos-venda" tabindex="0"><span class="label">Pós Venda</span></li>
           <li class="nav-subitem" data-parent="contatos" data-route="contatos-ofertas" tabindex="0"><span class="label">Ofertas</span></li>
+          <li class="nav-subitem" data-parent="contatos" data-route="contatos-historico" tabindex="0"><span class="label">Histórico</span></li>
         </ul>
       </li>
       <li class="nav-group" data-root="gerencia">
@@ -63,8 +64,8 @@
           <span class="submenu-caret" aria-hidden="true">▸</span>
         </div>
         <ul class="nav-submenu" aria-label="Submenu Gerencia">
-          <li class="nav-subitem" data-parent="gerencia" data-route="gerencia-config" tabindex="0"><span class="label">Configurações do Perfil</span></li>
-          <li class="nav-subitem" data-parent="gerencia" data-route="gerencia-mensagens" tabindex="0"><span class="label">Mensagens para Clientes</span></li>
+          <li class="nav-subitem" data-parent="gerencia" data-route="gerencia-config" tabindex="0"><span class="label">Configurações</span></li>
+          <li class="nav-subitem" data-parent="gerencia" data-route="gerencia-mensagens" tabindex="0"><span class="label">Mensagens</span></li>
         </ul>
       </li>
       <li class="nav-item nav-config" data-route="configuracoes" tabindex="0" style="display:none"><span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09A1.65 1.65 0 0 0 10 4.6V4a2 2 0 1 1 4 0v.09c0 .69.4 1.31 1 1.6.53.26 1.14.24 1.62-.07l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06c-.31.48-.33 1.09-.07 1.62.29.6.91 1 1.6 1H21a2 2 0 1 1 0 4h-.09c-.69 0-1.31.4-1.6 1z"></path></svg></span><span class="label">Configurações</span></li>

--- a/style.css
+++ b/style.css
@@ -1138,6 +1138,64 @@ input[name="telefone"] { width:18ch; }
   display: flex;
   flex-direction: column;
 }
+
+/* ===== Contatos histórico ===== */
+.contatos-historico .historico-tabs {
+  display: flex;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+}
+.contatos-historico .historico-tab {
+  border: 1px solid var(--color-border);
+  background: var(--surface);
+  color: var(--text-primary);
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.contatos-historico .historico-tab.is-active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+.contatos-historico .historico-grid {
+  grid-template-columns: repeat(12, 1fr);
+}
+.contatos-historico .historico-card {
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+}
+.contatos-historico .historico-card .card-body {
+  flex: 1;
+  overflow-x: auto;
+}
+.contatos-historico .historico-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 560px;
+}
+.contatos-historico .historico-table thead th {
+  text-align: left;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: var(--space-sm);
+  color: var(--text-muted);
+  background: var(--surface);
+}
+.contatos-historico .historico-table tbody td {
+  padding: var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+.contatos-historico .historico-table tbody tr:last-child td {
+  border-bottom: none;
+}
 .modal-client-page-btn { margin-right:auto; text-transform:uppercase; font-weight:600; }
 .btn-cliente-page { margin-right:var(--space-sm); }
 


### PR DESCRIPTION
## Summary
- rename the Gerência submenu labels to "Configurações" and "Mensagens" and add the new "Histórico" entry under Contatos
- implement the Contatos Histórico page with Pós Venda and Ofertas tabs backed by example table data and initialize its tab switching
- style the Histórico tabs and table to match existing spacing and typography

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc19e7e9c8333add051685890df30