### PR TITLE
Implement calendar modal enhancements and layout tweaks

### DIFF
--- a/style.css
+++ b/style.css
@@ -769,9 +769,10 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 [data-overlay]{position:fixed; inset:0; background:rgba(0,0,0,0.5); z-index:990;}
 #tagMenuPortal{z-index:1100;}
 
-/* número da data no canto direito, bem alto */
+/* número da data alinhado ao cabeçalho */
 .cal-day .cal-date{
-  position:absolute; top:4px; right:10px;
+  position:static;
+  margin-left:auto;
   font-weight:700;
 }
 
@@ -1268,8 +1269,8 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 .cal-toolbar {
   display:flex;
   align-items:center;
-  gap:1rem;
-  padding:16px 20px;
+  gap:0.75rem;
+  padding:10px 18px;
   background:transparent;
   border-radius:20px;
   box-shadow:none;
@@ -1374,8 +1375,8 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 .followup-badge.is-pending{background:#fce8d8;color:#b15b00;}
 .modal-dialog.modal-cliente-detalhe{max-width:840px;}
 .cal-nav button {
-  width:44px;
-  height:44px;
+  width:40px;
+  height:40px;
   border-radius:14px;
   display:grid;
   place-items:center;
@@ -1598,8 +1599,8 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
   --calendar-cell-min-width: 150px;
   display:grid;
   grid-template-columns:repeat(7, minmax(var(--calendar-cell-min-width), 1fr));
-  grid-auto-rows:minmax(150px,auto);
-  gap:1rem;
+  grid-auto-rows:minmax(80px,auto);
+  gap:0.85rem;
   width:100%;
   overflow-x:auto;
   padding-bottom:0.5rem;
@@ -1609,11 +1610,11 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
   background:#fff;
   border:1px solid rgba(15,23,42,0.06);
   border-radius:18px;
-  padding:0.75rem;
+  padding:0.65rem 0.75rem 0.75rem;
   display:flex;
   flex-direction:column;
   align-content:flex-start;
-  gap:0.45rem;
+  gap:0.5rem;
   position:relative;
   min-width:0;
   box-sizing:border-box;
@@ -1629,7 +1630,7 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
   border-style:dashed;
 }
 .calendar-day.is-empty {
-  padding:0.5rem 0.6rem;
+  padding:0.45rem 0.55rem 0.6rem;
   gap:0.3rem;
   min-height:auto;
 }
@@ -1640,19 +1641,25 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 .day-head {
   position:relative;
   display:flex;
-  align-items:center;
+  align-items:flex-start;
   justify-content:space-between;
   gap:0.5rem;
   height:auto;
   flex-wrap:nowrap;
-  margin-bottom:0.45rem;
 }
 .day-head > * { white-space:nowrap; }
-.calendar-day .calendar-item { margin-top:0.2rem; }
+.calendar-day .calendar-item { margin-top:0; }
+.day-body {
+  display:flex;
+  flex-direction:column;
+  gap:0.35rem;
+  flex:1 1 auto;
+  min-height:0;
+}
 .day-num {
   position:static;
   font-weight:700;
-  font-size:1.2rem;
+  font-size:1.1rem;
   color:#1f2937;
 }
 .today-badge {
@@ -1692,7 +1699,6 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
   display:flex;
   align-items:center;
   gap:0.35rem;
-  margin-top:0.2rem;
   min-width:0;
   width:100%;
 }
@@ -1770,6 +1776,172 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 .calendar-card.desfalque { background:#555; color:#fff; }
 .calendar-card strong { display:block; }
 .calendar-card .switch { margin-top:0.5rem; }
+.calendar-modal {
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+  min-height:0;
+}
+.calendar-modal__header {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  flex-wrap:wrap;
+  gap:0.75rem;
+}
+.calendar-modal__content {
+  display:flex;
+  flex-direction:column;
+  gap:1.25rem;
+  max-height:60vh;
+  overflow:auto;
+  padding-right:0.25rem;
+}
+.calendar-modal--eventos .calendar-modal__content { gap:1rem; }
+.evento-group {
+  background:#f8fafc;
+  border-radius:12px;
+  border:1px solid rgba(15,23,42,0.06);
+  padding:0.85rem 1rem;
+  display:flex;
+  flex-direction:column;
+  gap:0.75rem;
+}
+.evento-group__header {
+  font-weight:700;
+  font-size:0.85rem;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+  color:#475569;
+  margin:0;
+}
+.evento-group__list {
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  gap:0.6rem;
+}
+.evento-item {
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:1rem;
+  padding:0.6rem 0.75rem;
+  border-radius:10px;
+  background:#fff;
+  border:1px solid rgba(15,23,42,0.05);
+}
+.evento-info { flex:1 1 auto; min-width:0; }
+.evento-info strong { display:block; font-size:0.95rem; margin-bottom:0.25rem; }
+.evento-subtitle,
+.evento-tag {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:999px;
+  padding:0.15rem 0.55rem;
+  font-size:0.7rem;
+  font-weight:600;
+  letter-spacing:0.05em;
+  text-transform:uppercase;
+  margin-right:0.35rem;
+}
+.evento-subtitle { background:rgba(15,23,42,0.06); color:#1f2937; }
+.evento-tag { background:#fee2b3; color:#92400e; }
+.evento-note { margin:0.35rem 0 0; font-size:0.8rem; color:#475569; white-space:pre-wrap; }
+.evento-actions { display:flex; align-items:center; gap:0.5rem; flex:0 0 auto; }
+.evento-toggle {
+  border:1px solid rgba(15,23,42,0.12);
+  border-radius:999px;
+  padding:0.3rem 0.9rem;
+  background:#fff;
+  font-weight:600;
+  cursor:pointer;
+  transition:background 0.2s, color 0.2s, border-color 0.2s;
+}
+.evento-toggle.is-active { background:#16a34a; color:#fff; border-color:#16a34a; }
+.calendar-modal--folgas .calendar-modal__content {
+  display:grid;
+  gap:1.5rem;
+  grid-template-columns:minmax(0,1fr);
+}
+@media(min-width:900px){
+  .calendar-modal--folgas .calendar-modal__content {
+    grid-template-columns:minmax(0,2fr) minmax(0,1fr);
+  }
+}
+.folgas-month-nav { display:flex; align-items:center; gap:0.75rem; }
+.folgas-month-title { margin:0; font-size:1.05rem; font-weight:700; text-transform:capitalize; }
+.btn-icon.folgas-prev,
+.btn-icon.folgas-next {
+  background:#fff;
+  border:1px solid rgba(15,23,42,0.12);
+  border-radius:10px;
+  width:36px;
+  height:36px;
+  display:grid;
+  place-items:center;
+  cursor:pointer;
+}
+.folgas-admin-buttons { display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; }
+.folgas-calendar {
+  background:#fff;
+  border:1px solid rgba(15,23,42,0.05);
+  border-radius:14px;
+  padding:0.75rem;
+  display:flex;
+  flex-direction:column;
+  gap:0.75rem;
+}
+.folgas-weekdays { display:grid; grid-template-columns:repeat(7,minmax(0,1fr)); gap:0.25rem; text-align:center; font-size:0.75rem; font-weight:600; color:#475569; }
+.folgas-weekdays span { padding:0.25rem 0; background:#f8fafc; border-radius:8px; }
+.folgas-cells { display:grid; grid-template-columns:repeat(7,minmax(0,1fr)); gap:0.45rem; }
+.folga-cell {
+  background:#fdfdfd;
+  border:1px solid rgba(15,23,42,0.06);
+  border-radius:12px;
+  padding:0.35rem 0.4rem;
+  display:flex;
+  flex-direction:column;
+  gap:0.35rem;
+  min-height:68px;
+  cursor:pointer;
+  transition:border-color 0.2s, box-shadow 0.2s;
+}
+.folga-cell.is-out { background:#f3f4f6; color:#9ca3af; cursor:default; }
+.folga-cell.has-folga { border-color:#16a34a44; }
+.folga-cell.is-selected { border-color:#16a34a; box-shadow:0 0 0 2px rgba(22,163,74,0.2); }
+.folga-cell-head { font-weight:700; font-size:0.9rem; display:flex; justify-content:flex-end; }
+.folga-cell-body { display:flex; flex-direction:column; gap:0.3rem; }
+.folga-chip {
+  border:none;
+  background:#1f2937;
+  color:#fff;
+  border-radius:999px;
+  padding:0.25rem 0.6rem;
+  font-size:0.72rem;
+  font-weight:600;
+  cursor:pointer;
+  transition:transform 0.15s, box-shadow 0.15s;
+}
+.folga-chip:hover { transform:translateY(-1px); box-shadow:0 4px 12px rgba(15,23,42,0.18); }
+.folga-chip.is-selected { background:#16a34a; }
+.folgas-manage { display:flex; flex-direction:column; gap:1rem; }
+.folga-form .form-row { display:flex; flex-direction:column; gap:0.35rem; margin-bottom:0.6rem; }
+.folgas-form-actions { display:flex; flex-wrap:wrap; gap:0.5rem; }
+.folgas-ferias {
+  border:1px dashed rgba(15,23,42,0.12);
+  border-radius:12px;
+  padding:0.75rem;
+  display:flex;
+  flex-direction:column;
+  gap:0.75rem;
+}
+.folgas-ferias-grid { display:grid; gap:0.5rem; grid-template-columns:repeat(auto-fit, minmax(160px,1fr)); align-items:end; }
+.folgas-ferias-grid button { justify-self:start; }
+.folgas-ferias[hidden] { display:none; }
 .destinos-table { width:100%; border-collapse:collapse; margin-top:0.25rem; }
 .destinos-table th, .destinos-table td { padding:0.25rem; text-align:left; }
 .destinos-table th { font-weight:600; }
@@ -1958,7 +2130,7 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 .dash-add-menu button:hover{background:#f5f7fa}
 
 .calendar {
-  background:#f1f5fb;
+  background:#f7f7f8;
   border-radius:var(--radius-lg);
   padding:24px;
   width:100%;


### PR DESCRIPTION
## Summary
- add dedicated modals for viewing events and managing folgas, including admin-only actions and vacation markers
- refactor month and week renderers to separate header/body content and shrink empty calendar cells while preserving content layout
- refresh calendar styling to lighten the board, tighten toolbar spacing, and support the new modal interfaces

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14b75d9248333b644bbc1029e4e78