### PR TITLE
Fix event modal cancel button declaration conflict

### DIFF
--- a/script.js
+++ b/script.js
@@ -3140,9 +3140,6 @@ function initCalendarioPage() {
     const cancelBtn = modal.querySelector('[data-modal-close]');
     saveBtn.style.display='';
     if(cancelBtn) cancelBtn.textContent='Cancelar';
-    const cancelBtn = modal.querySelector('[data-modal-close]');
-    saveBtn.style.display='';
-    if(cancelBtn) cancelBtn.textContent='Cancelar';
     saveBtn.removeAttribute('data-action');
     saveBtn.setAttribute('type','submit');
     const title=document.getElementById('modal-title');


### PR DESCRIPTION
## Summary
- remove duplicated `cancelBtn` declaration inside `openEventoModal`
- prevent runtime `Identifier 'cancelBtn' has already been declared` error that stopped UI rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d15352ede083338ac3cb19d22ba0d3