### PR TITLE
Ajustes no modal de folgas e contatos

### DIFF
--- a/style.css
+++ b/style.css
@@ -1107,22 +1107,22 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 }
 .contatos-tab {
   border:none;
-  border-radius:999px;
+  border-radius:12px;
   background:#f1f5f9;
   color:#475569;
   font-weight:700;
   letter-spacing:0.05em;
   text-transform:uppercase;
-  padding:0.6rem 1.2rem;
+  padding:0.6rem 1.15rem;
   cursor:pointer;
   transition:all 0.2s ease;
-  box-shadow:inset 0 1px 2px rgba(15,23,42,0.08);
+  box-shadow:inset 0 0 0 1px rgba(15,23,42,0.08);
 }
 .contatos-tab:hover { background:#e2e8f0; }
 .contatos-tab.is-active {
   background:#1f2937;
   color:#fff;
-  box-shadow:0 12px 26px rgba(15,23,42,0.2);
+  box-shadow:0 12px 26px rgba(15,23,42,0.18);
 }
 .contatos-panels {
   display:flex;
@@ -1189,6 +1189,15 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
   font-size:0.7rem;
   letter-spacing:0.05em;
   text-transform:uppercase;
+}
+.contato-chip__status {
+  background:#15803d;
+  color:#fff;
+  border-radius:10px;
+  padding:0.1rem 0.55rem;
+  font-size:0.68rem;
+  text-transform:uppercase;
+  letter-spacing:0.05em;
 }
 .contato-chip__meta,
 .contato-chip__footer {
@@ -1827,7 +1836,7 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 }
 .calendar-day {
   background:#fff;
-  border:1px solid rgba(15,23,42,0.06);
+  border:1px solid rgba(15,23,42,0.12);
   border-radius:18px;
   padding:0.65rem 0.75rem 0.75rem;
   display:flex;
@@ -2106,14 +2115,9 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 }
 .evento-toggle.is-active { background:#16a34a; color:#fff; border-color:#16a34a; }
 .calendar-modal--folgas .calendar-modal__content {
-  display:grid;
-  gap:1.5rem;
-  grid-template-columns:minmax(0,1fr);
-}
-@media(min-width:900px){
-  .calendar-modal--folgas .calendar-modal__content {
-    grid-template-columns:minmax(0,2fr) minmax(0,1fr);
-  }
+  display:flex;
+  flex-direction:column;
+  gap:1.75rem;
 }
 .folgas-month-nav { display:flex; align-items:center; gap:0.75rem; }
 .folgas-month-title { margin:0; font-size:1.05rem; font-weight:700; text-transform:capitalize; }
@@ -2131,25 +2135,26 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 .folgas-admin-buttons { display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; }
 .folgas-calendar {
   background:#fff;
-  border:1px solid rgba(15,23,42,0.05);
-  border-radius:14px;
-  padding:0.75rem;
+  border:1px solid rgba(15,23,42,0.08);
+  border-radius:18px;
+  padding:1.1rem 1.25rem;
   display:flex;
   flex-direction:column;
-  gap:0.75rem;
+  gap:0.85rem;
+  box-shadow:0 18px 40px rgba(15,23,42,0.12);
 }
 .folgas-weekdays { display:grid; grid-template-columns:repeat(7,minmax(0,1fr)); gap:0.25rem; text-align:center; font-size:0.75rem; font-weight:600; color:#475569; }
 .folgas-weekdays span { padding:0.25rem 0; background:#f8fafc; border-radius:8px; }
 .folgas-cells { display:grid; grid-template-columns:repeat(7,minmax(0,1fr)); gap:0.45rem; }
 .folga-cell {
   background:#fdfdfd;
-  border:1px solid rgba(15,23,42,0.06);
-  border-radius:12px;
-  padding:0.35rem 0.4rem;
+  border:1px solid rgba(15,23,42,0.08);
+  border-radius:14px;
+  padding:0.45rem 0.5rem;
   display:flex;
   flex-direction:column;
-  gap:0.35rem;
-  min-height:68px;
+  gap:0.4rem;
+  min-height:72px;
   cursor:pointer;
   transition:border-color 0.2s, box-shadow 0.2s;
 }
@@ -2162,16 +2167,29 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
   border:none;
   background:#1f2937;
   color:#fff;
-  border-radius:999px;
-  padding:0.25rem 0.6rem;
-  font-size:0.72rem;
+  border-radius:12px;
+  padding:0.4rem 0.65rem;
+  font-size:0.75rem;
   font-weight:600;
   cursor:pointer;
   transition:transform 0.15s, box-shadow 0.15s;
+  display:flex;
+  align-items:center;
+  gap:0.35rem;
+  text-align:left;
 }
 .folga-chip:hover { transform:translateY(-1px); box-shadow:0 4px 12px rgba(15,23,42,0.18); }
 .folga-chip.is-selected { background:#16a34a; }
-.folgas-manage { display:flex; flex-direction:column; gap:1rem; }
+.folgas-manage {
+  display:flex;
+  flex-direction:column;
+  gap:1.25rem;
+  background:#fff;
+  border:1px solid rgba(15,23,42,0.08);
+  border-radius:18px;
+  padding:1.25rem;
+  box-shadow:0 18px 40px rgba(15,23,42,0.12);
+}
 .folga-form .form-row { display:flex; flex-direction:column; gap:0.35rem; margin-bottom:0.6rem; }
 .folgas-form-actions { display:flex; flex-wrap:wrap; gap:0.5rem; }
 .folgas-ferias {
@@ -2290,6 +2308,34 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
 .w2h2 { width:300px; height:300px; }
 
 /* ===== New styles ===== */
+.dashboard-layout {
+  --board-cols:5;
+  --board-gap:clamp(14px,2vw,24px);
+  --board-cell-height:clamp(160px,22vw,220px);
+  display:grid;
+  place-items:center;
+  padding:clamp(24px,3vw,36px) 0;
+  position:relative;
+}
+.dashboard-board {
+  grid-area:1 / 1 / 2 / 2;
+  width:min(100%, 1240px);
+  border-radius:28px;
+  background:#fff;
+  box-shadow:0 24px 60px rgba(15,23,42,0.14);
+  display:grid;
+  grid-template-columns:repeat(var(--board-cols), minmax(0,1fr));
+  grid-auto-rows:var(--board-cell-height);
+  gap:var(--board-gap);
+  padding:clamp(20px,2.5vw,32px);
+  box-sizing:border-box;
+  pointer-events:none;
+}
+.dashboard-board__cell {
+  border:1px dashed rgba(15,23,42,0.12);
+  border-radius:18px;
+  background:rgba(248,250,252,0.78);
+}
 .dashboard-grid{ /* Ajuste: grade fixa com 4 colunas e rolagem horizontal suave */
   --dash-card-min-width: clamp(200px, 22vw, 260px);
   display:grid;
@@ -2306,6 +2352,8 @@ body[data-route="clientes-cadastro"] .card[data-card-id="cadastro-clientes"] .ca
   scroll-behavior:smooth;
   overscroll-behavior-inline:contain;
   scroll-snap-type:x proximity;
+  position:relative;
+  z-index:1;
 }
 .dashboard-grid::-webkit-scrollbar{height:6px;}
 .dashboard-grid::-webkit-scrollbar-thumb{background:rgba(0,0,0,0.18);border-radius:999px;}


### PR DESCRIPTION
## Resumo
- Reorganiza o modal de folgas para usar cartões empilhados, chips padronizados e limpeza automática do formulário após salvar folgas ou férias.
- Reescreve a página de contatos para usar os follow-ups reais dos clientes em todos os painéis, mantendo filtros e histórico vinculados aos dados existentes.
- Adiciona um quadro de fundo expansível ao dashboard e ajusta estilos (bordas do calendário e abas de contatos) para manter o visual consistente.

## Testes
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d19704a6bc833386b1b6e18b49b2af